### PR TITLE
Created Link Data Type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,9 @@ dependencies = [
 [[package]]
 name = "object"
 version = "0.1.0"
+dependencies = [
+ "logging",
+]
 
 [[package]]
 name = "once_cell"

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,139 @@
+# CrabDB Python Client
+
+A Python client for interacting with CrabDB using the binary TCP protocol.
+
+## Features
+
+- **Interactive Mode**: Full-featured REPL with command history and graceful Ctrl+C handling
+- **Single Command Mode**: Execute individual commands and exit
+- **Type Support**: All CrabDB data types (Null, Int, Text, List, Map, Link)
+- **Link Resolution**: Automatic link resolution with configurable depth
+- **JSON Support**: Parse JSON values for complex data structures
+
+## Usage
+
+### Interactive Mode
+
+```bash
+python cli.py
+```
+
+This starts an interactive session where you can execute multiple commands:
+
+```
+CrabDB Interactive Client
+Type 'help' for commands or 'quit' to exit
+Press Ctrl+C to exit gracefully
+Connected to localhost:7227
+crabdb> set user1 "John Doe"
+Set user1 = "John Doe"
+crabdb> set user2 {"name": "Jane", "age": 30}
+Set user2 = {
+  "name": "Jane",
+  "age": 30
+}
+crabdb> get user1
+"John Doe"
+crabdb> quit
+```
+
+### Single Command Mode
+
+```bash
+python3 cli.py --command "get user1"
+python3 cli.py -c "set numbers [1, 2, 3, 4, 5]"
+```
+
+### Connection Options
+
+```bash
+python3 cli.py --host 192.168.1.100 --port 7227
+```
+
+## Commands
+
+- `get <key> [link_depth]` - Get value by key, optionally resolve links
+- `set <key> <value>` - Set key to value (supports JSON)
+- `delete <key>` - Delete key
+- `link <key> <target_key>` - Create a link from key to target_key
+- `help` - Show available commands
+- `quit`/`exit` - Exit the client
+
+## Examples
+
+### Basic Operations
+```
+set name "Alice"
+set age 25
+get name
+delete age
+```
+
+### Complex Data Types
+```
+set user {"name": "Bob", "email": "bob@example.com", "active": true}
+set tags ["python", "database", "rust"]
+set config {"debug": false, "max_connections": 100}
+```
+
+### Links and Resolution
+```
+set user1 {"name": "Alice", "role": "admin"}
+set user2 {"name": "Bob", "role": "user"}
+link current_user user1
+get current_user        # Returns link object
+get current_user 1      # Resolves link and returns user1 data
+```
+
+### Links in Maps and Lists
+```
+# Create target data first
+set user1 {"name": "Alice", "role": "admin"}
+set user2 {"name": "Bob", "role": "user"}
+
+# Links as map field values
+set team {
+  "lead": {"_link": "user1"},
+  "member": {"_link": "user2"},
+  "project": "CrabDB"
+}
+
+# Links in lists
+set user_list [
+  {"_link": "user1"},
+  {"_link": "user2"},
+  "some string",
+  42
+]
+
+# Complex nested structure with links
+set organization {
+  "name": "TechCorp",
+  "departments": [
+    {
+      "name": "Engineering", 
+      "head": {"_link": "user1"},
+      "members": [{"_link": "user2"}, {"_link": "user1"}]
+    }
+  ],
+  "ceo": {"_link": "user1"}
+}
+
+# Resolve links at different depths
+get team 1              # Resolves direct links
+get organization 2      # Resolves nested links
+```
+
+## Requirements
+
+- Python 3.6+
+- No external dependencies (uses only standard library)
+
+## Error Handling
+
+The client handles various error conditions gracefully:
+- Connection failures
+- Server errors
+- Invalid commands
+- Malformed data
+- Ctrl+C interruption (graceful shutdown)

--- a/client/cli.py
+++ b/client/cli.py
@@ -1,937 +1,218 @@
 #!/usr/bin/env python3
+"""
+CrabDB CLI Interface
 
-# This code was written by an LLM. I couldn't be bothered to write simple test
-# program from scratch
-import socket
-import struct
+Provides both single-line and interactive modes for CrabDB client.
+"""
+
 import argparse
+import json
+import signal
 import sys
-import shlex  # For splitting input lines in interactive mode
-import signal  # For handling Ctrl+C
+from typing import Any, Optional
 
-# Define constants for data types and request types as per the protocol.
-TYPE_NULL = 0
-TYPE_INT = 1
-TYPE_TEXT = 2
-TYPE_LIST = 3
-TYPE_MAP = 4
-TYPE_LINK = 5
-
-REQUEST_GET = 0
-REQUEST_SET = 1
-REQUEST_DELETE = 2
-REQUEST_CLOSE = 255
-
-# Define a mapping from string names to type codes for user input.
-DATA_TYPE_MAP = {
-    "int": TYPE_INT,
-    "text": TYPE_TEXT,
-    "null": TYPE_NULL,
-    "list": TYPE_LIST,
-    "map": TYPE_MAP,
-    "link": TYPE_LINK,
-}
+from crabdb_client import CrabDBClient, CrabDBError
 
 
-def _read_full_response(sock):
-    """
-    Reads the full response from the socket based on the 8-byte length prefix.
-    Returns (response_data_content, response_total_len) or (None, error_message) on error.
-    """
-    try:
-        # Read the 8-byte response length
-        len_bytes = sock.recv(8)
-        if not len_bytes:
-            return None, "Error: Did not receive response length from server. Connection closed?"
-        if len(len_bytes) < 8:
-            return None, f"Error: Incomplete length header received. Expected 8 bytes, got {len(len_bytes)}."
-        response_total_len = struct.unpack('>Q', len_bytes)[0]
-
-        # Read the remaining response data as indicated by response_total_len
-        response_data_content = b''
-        bytes_received = 0
-        while bytes_received < response_total_len:
-            # Read in chunks, ensure we don't try to read more than available or remaining
-            chunk = sock.recv(min(response_total_len - bytes_received, 4096))
-            if not chunk:
-                return None, "Error: Connection closed prematurely by server while reading response data content."
-            response_data_content += chunk
-            bytes_received += len(chunk)
-
-        return response_data_content, response_total_len
-    except socket.error as e:
-        return None, f"Socket communication error: {e}"
-    except Exception as e:
-        return None, f"An unexpected error occurred during response reading: {e}"
-
-
-def execute_command_on_socket(sock, payload):
-    """
-    Sends a payload on an *existing, open* socket and reads the response.
-    Returns the parsed response string.
-    """
-    try:
-        sock.sendall(payload)
-        response_data_content, response_total_len = _read_full_response(sock)
-
-        if response_data_content is None:
-            # _read_full_response returned an error string in response_total_len
-            return response_total_len
-
-        return parse_server_response(response_data_content, response_total_len)
-    except socket.error as e:
-        return f"Socket communication error: {e}"
-    except Exception as e:
-        return f"An unexpected error occurred during command execution: {e}"
-
-
-def execute_command_once(host, port, payload):
-    """
-    Establishes a new TCP connection, sends the payload, reads the response,
-    and then closes the connection. Suitable for single commands.
-    """
-    try:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.connect((host, port))
-            # <--- THIS LINE WAS MISSING AND HAS BEEN ADDED BACK
-            s.sendall(payload)
-            response_data_content, response_total_len = _read_full_response(s)
-
-            if response_data_content is None:
-                return response_total_len  # Contains the error message from _read_full_response
-
-            return parse_server_response(response_data_content, response_total_len)
-    except socket.error as e:
-        return f"Socket error: {e}"
-    except Exception as e:
-        return f"An unexpected error occurred: {e}"
-
-
-def parse_server_response(response_data_content, declared_len):
-    """
-    Parses the binary response content received from the database.
-    This content is everything *after* the initial 8-byte Response Length.
-    """
-    if not response_data_content:
-        return "Empty response content received from server."
-
-    # Check if the content indicates an error (single byte 255)
-    # Per the latest clarification: Error is just 8-byte length (which would be 1) + 1-byte 255
-    if len(response_data_content) == 1 and struct.unpack('>B', response_data_content[0:1])[0] == 255:
-        return "SERVER ERROR: Operation failed (code 255)."
-
-    # Otherwise, it must be a successful data object (Data Type + Data Payload)
-    if len(response_data_content) < 1:
-        return "ERROR: Malformed successful response: missing Data Type byte."
-
-    data_type = struct.unpack('>B', response_data_content[0:1])[0]
-    cursor = 1  # Points to the start of the Data Payload
-
-    if data_type == TYPE_NULL:
-        # Null has no payload. Declared length must match 1 (for the Data Type byte itself).
-        if declared_len != 1:
-            return f"ERROR: Malformed NULL response. Declared length {declared_len} but expected 1."
-        return "Result: None (Null Value)"
-    elif data_type == TYPE_INT:
-        # Int payload is 8 bytes. Declared length must match 1 (Data Type) + 8 (Int payload).
-        expected_len = 1 + 8
-        if declared_len != expected_len or len(response_data_content) < cursor + 8:
-            return f"ERROR: Incomplete INT data payload. Declared length {declared_len}, content length {len(response_data_content) - cursor} bytes, expected {8}."
-        int_value = struct.unpack(
-            '>q', response_data_content[cursor:cursor+8])[0]
-        return f"Result (Int): {int_value}"
-    elif data_type == TYPE_TEXT:
-        # Text payload has a 2-byte length prefix + 'm' bytes of text data.
-        if len(response_data_content) < cursor + 2:
-            return f"ERROR: Incomplete TEXT length. Received {len(response_data_content) - cursor} bytes, expected 2."
-        text_len = struct.unpack(
-            '>H', response_data_content[cursor:cursor+2])[0]
-        cursor += 2
-
-        # 1 for Data Type, 2 for text length, text_len for text data
-        expected_len = 1 + 2 + text_len
-        if declared_len != expected_len or len(response_data_content) < cursor + text_len:
-            return f"ERROR: Incomplete TEXT data payload. Declared length {declared_len}, content length {len(response_data_content) - cursor} bytes, expected {text_len}."
-        text_value = response_data_content[cursor:cursor +
-                                           text_len].decode('utf-8')
-        return f"Result (Text): '{text_value}'"
-    elif data_type == TYPE_LIST:
-        # List payload has a 2-byte count prefix + serialized objects
-        if len(response_data_content) < cursor + 2:
-            return f"ERROR: Incomplete LIST count. Received {len(response_data_content) - cursor} bytes, expected 2."
-        list_count = struct.unpack(
-            '>H', response_data_content[cursor:cursor+2])[0]
-        cursor += 2
-
-        result, _ = _deserialize_list(
-            response_data_content, cursor, list_count)
-        return f"Result (List): {result}"
-    elif data_type == TYPE_MAP:
-        # Map payload has a 2-byte field count prefix + field entries
-        if len(response_data_content) < cursor + 2:
-            return f"ERROR: Incomplete MAP field count. Received {len(response_data_content) - cursor} bytes, expected 2."
-        field_count = struct.unpack(
-            '>H', response_data_content[cursor:cursor+2])[0]
-        cursor += 2
-
-        result, _ = _deserialize_map(
-            response_data_content, cursor, field_count)
-        return f"Result (Map): {result}"
-    elif data_type == TYPE_LINK:
-        # Link payload has a 2-byte length prefix + key data (same format as Key)
-        if len(response_data_content) < cursor + 2:
-            return f"ERROR: Incomplete LINK length. Received {len(response_data_content) - cursor} bytes, expected 2."
-        link_len = struct.unpack(
-            '>H', response_data_content[cursor:cursor+2])[0]
-        cursor += 2
+class CrabDBCLI:
+    """Command-line interface for CrabDB"""
+    
+    def __init__(self, host: str = "localhost", port: int = 7227):
+        self.client = CrabDBClient(host, port)
+        self.running = True
         
-        # Check if we have enough data for the link key
-        expected_len = 1 + 2 + link_len  # Data Type + Length + Key
-        if declared_len != expected_len or len(response_data_content) < cursor + link_len:
-            return f"ERROR: Incomplete LINK data payload. Declared length {declared_len}, content length {len(response_data_content) - cursor} bytes, expected {link_len}."
-        link_key = response_data_content[cursor:cursor + link_len].decode('utf-8')
-        return f"Result (Link): -> '{link_key}'"
-    else:
-        return f"ERROR: Unknown Data Type received in successful response: {data_type} (Expected 0, 1, 2, 3, 4, or 5)."
-
-
-def construct_set_payload(key, value_str, value_type):
-    """
-    Constructs the binary payload for a SET request.
-    """
-    key_bytes = key.encode('utf-8')
-    key_len_bytes = struct.pack('>H', len(key_bytes))  # 2 bytes for key length
-
-    # --- Construct the data payload based on type ---
-    data_type_byte = struct.pack('>B', value_type)
-    data_payload = b''
-    if value_type == TYPE_INT:
-        try:
-            # Pack as a signed 8-byte integer (long long)
-            data_payload = struct.pack('>q', int(value_str))
-        except ValueError:
-            raise ValueError(f"'{value_str}' is not a valid integer.")
-    elif value_type == TYPE_TEXT:
-        value_bytes = value_str.encode('utf-8')
-        # Pack the text length (2 bytes) followed by the text itself
-        data_payload = struct.pack('>H', len(value_bytes)) + value_bytes
-    elif value_type == TYPE_NULL:
-        # Null has no data payload
-        pass
-    elif value_type == TYPE_LIST:
-        # Parse JSON-like list format: [item1, item2, ...]
-        data_payload = _serialize_list(value_str)
-    elif value_type == TYPE_MAP:
-        # Parse JSON-like map format: {"key1": value1, "key2": value2}
-        data_payload = _serialize_map(value_str)
-    elif value_type == TYPE_LINK:
-        # Link type uses the same format as a key: 2-byte length + UTF-8 key data
-        link_key_bytes = value_str.encode('utf-8')
-        data_payload = struct.pack('>H', len(link_key_bytes)) + link_key_bytes
-    else:
-        raise ValueError(f"Unsupported data type for SET: {value_type}")
-
-    # --- Assemble the request-specific part ---
-    request_specific_part = key_len_bytes + \
-        key_bytes + data_type_byte + data_payload
-
-    # --- Assemble the full payload ---
-    request_type_byte = struct.pack('>B', REQUEST_SET)
-    # The total length is the length of everything *after* the initial 8-byte length field.
-    total_len = len(request_type_byte) + len(request_specific_part)
-    total_len_bytes = struct.pack('>Q', total_len)
-
-    return total_len_bytes + request_type_byte + request_specific_part
-
-
-def construct_get_payload(key):
-    """
-    Constructs the binary payload for a GET request without parameters.
-    """
-    key_bytes = key.encode('utf-8')
-
-    # --- Assemble the request-specific part ---
-    request_specific_part = struct.pack('>H', len(key_bytes)) + key_bytes
-
-    # --- Assemble the full payload ---
-    request_type_byte = struct.pack('>B', REQUEST_GET)
-    # The total length is the length of everything *after* the initial 8-byte length field.
-    total_len = len(request_type_byte) + len(request_specific_part)
-    total_len_bytes = struct.pack('>Q', total_len)
-
-    return total_len_bytes + request_type_byte + request_specific_part
-
-
-def construct_get_payload_with_params(key, link_resolution_depth=None):
-    """
-    Constructs the binary payload for a GET request with optional parameters.
+        # Set up signal handler for graceful shutdown
+        signal.signal(signal.SIGINT, self._signal_handler)
     
-    Args:
-        key: The key to retrieve
-        link_resolution_depth: Optional maximum link resolution depth (0-255)
-    """
-    key_bytes = key.encode('utf-8')
-    
-    # Start with key
-    request_specific_part = struct.pack('>H', len(key_bytes)) + key_bytes
-    
-    # Add parameters if any
-    if link_resolution_depth is not None:
-        # Add number of parameters (1 byte)
-        request_specific_part += struct.pack('>B', 1)  # 1 parameter
-        
-        # Add link resolution parameter (type 1, 1-byte value)
-        request_specific_part += struct.pack('>B', 1)  # Parameter type: Link Resolution
-        request_specific_part += struct.pack('>B', link_resolution_depth)  # Max resolution depth
-    
-    # --- Assemble the full payload ---
-    request_type_byte = struct.pack('>B', REQUEST_GET)
-    total_len = len(request_type_byte) + len(request_specific_part)
-    total_len_bytes = struct.pack('>Q', total_len)
-
-    return total_len_bytes + request_type_byte + request_specific_part
-
-
-def construct_delete_payload(key):
-    """
-    Constructs the binary payload for a DELETE request.
-    """
-    # --- Encode the key ---
-    key_bytes = key.encode('utf-8')
-    key_len = len(key_bytes)
-    if key_len > 65535:  # 2^16 - 1
-        raise ValueError(f"Key too long: {key_len} bytes (max 65535)")
-    key_len_bytes = struct.pack('>H', key_len)
-
-    # --- Assemble the request-specific part ---
-    request_specific_part = key_len_bytes + key_bytes
-
-    # --- Assemble the full payload ---
-    request_type_byte = struct.pack('>B', REQUEST_DELETE)
-    # The total length is the length of everything *after* the initial 8-byte length field.
-    total_len = len(request_type_byte) + len(request_specific_part)
-    total_len_bytes = struct.pack('>Q', total_len)
-
-    # Combine all parts
-    payload = total_len_bytes + request_type_byte + request_specific_part
-    return payload
-
-
-def construct_close_payload():
-    """
-    Constructs the binary payload for a CLOSE request.
-    The CLOSE command has no additional data, just the command type.
-    """
-    # --- Assemble the full payload ---
-    request_type_byte = struct.pack('>B', REQUEST_CLOSE)
-    # The total length is just the length of the command type byte
-    total_len = len(request_type_byte)
-    total_len_bytes = struct.pack('>Q', total_len)
-
-    return total_len_bytes + request_type_byte
-
-
-def send_close_request(sock):
-    """
-    Send a close request to the server and handle the response.
-    Returns True if successful, False otherwise.
-    """
-    try:
-        close_payload = construct_close_payload()
-        sock.send(close_payload)
-        print("Close request sent to server.")
-
-        # The server should close the connection after receiving CLOSE
-        # We don't expect a response, but we'll try to read to see if connection closes
-        try:
-            response = sock.recv(1024)
-            if not response:
-                print("Server closed the connection gracefully.")
-                return True
-            else:
-                print("Server sent unexpected response to close request.")
-                return True
-        except socket.error:
-            # Connection closed by server, which is expected
-            print("Server closed the connection.")
-            return True
-
-    except socket.error as e:
-        print(f"Error sending close request: {e}")
-        return False
-
-
-def interactive_mode(initial_host, initial_port):
-    """
-    Runs the CLI client in interactive mode, keeping the database connection open.
-    """
-    current_host = initial_host
-    current_port = initial_port
-    db_socket = None
-
-    def establish_connection():
-        nonlocal db_socket
-        if db_socket:
-            try:
-                db_socket.close()
-                print("Closing existing connection.")
-            except socket.error as e:
-                print(f"Error closing existing socket: {e}", file=sys.stderr)
-            db_socket = None
-
-        print(f"Attempting to connect to {current_host}:{current_port}...")
-        try:
-            new_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            new_socket.connect((current_host, current_port))
-            db_socket = new_socket
-            print("Connection established.")
-            return True
-        except socket.error as e:
-            print(f"Failed to connect to {current_host}:{
-                  current_port}: {e}", file=sys.stderr)
-            db_socket = None
-            return False
-        except Exception as e:
-            print(f"An unexpected error occurred during connection: {
-                  e}", file=sys.stderr)
-            db_socket = None
-            return False
-
-    # Establish initial connection
-    if not establish_connection():
-        print("Starting interactive mode without an active connection. Use 'connect' to establish one.")
-
-    # Set up signal handler for graceful shutdown on Ctrl+C
-    def signal_handler(signum, frame):
-        print("\n\nReceived interrupt signal (Ctrl+C)")
-        if db_socket:
-            print("Sending close request to server...")
-            send_close_request(db_socket)
-            try:
-                db_socket.close()
-            except:
-                pass
-        print("Exiting interactive mode.")
+    def _signal_handler(self, signum, frame):
+        """Handle Ctrl+C gracefully"""
+        print("\nShutting down gracefully...")
+        self.running = False
+        self.client.disconnect()
         sys.exit(0)
-
-    signal.signal(signal.SIGINT, signal_handler)
-
-    print("\nEntering interactive mode.")
-    print("Commands: set <key> <value> --type <int|text|null|list|map|link> | get <key> [--resolve-links <depth>] | delete <key> | close | connect <host>:<port> | exit | quit")
-    print("Quote values with spaces, e.g., set \"my key\" \"my value\" --type text")
-    print("Use 'link' type to reference other keys, e.g., set mylink mykey --type link")
-    print("Use --resolve-links with GET to automatically resolve link references")
-    print("Press Ctrl+C to send close request and exit gracefully.")
-
-    try:
-        while True:
-            try:
-                # Update prompt to show connection status
-                status_indicator = ' disconnected' if db_socket is None else ''
-                user_input = input(f"CrabDB ({current_host}:{current_port}{
-                                   status_indicator})> ").strip()
-                if not user_input:
-                    continue
-
-                parts = shlex.split(user_input)
-                command = parts[0].lower()
-
-                if command in ['exit', 'quit']:
-                    if db_socket:
-                        print("Sending close request to server...")
-                        send_close_request(db_socket)
-                    print("Exiting interactive mode.")
-                    break
-                elif command == 'connect':
-                    if len(parts) == 2:
-                        try:
-                            host_port_str = parts[1]
-                            if ':' in host_port_str:
-                                new_host, new_port_str = host_port_str.split(
-                                    ':')
-                                new_port = int(new_port_str)
-                                current_host = new_host
-                                current_port = new_port
-                                establish_connection()  # Attempt to connect to new host/port
-                            else:
-                                print(
-                                    "Invalid connect format. Use: connect <host>:<port>")
-                        except ValueError:
-                            print("Invalid port number.")
-                        except Exception as e:
-                            print(f"Error changing connection: {e}")
-                    else:
-                        print("Usage: connect <host>:<port>")
-                elif command == 'set':
-                    if db_socket is None:
-                        print(
-                            "Error: Not connected to the database. Use 'connect' first.")
-                        continue
-
-                    if '--type' not in parts:
-                        print("Error: Missing --type argument for set command.")
-                        continue
-
+    
+    def _parse_value(self, value_str: str) -> Any:
+        """Parse a string value into appropriate Python type"""
+        # Try to parse as JSON first
+        try:
+            return json.loads(value_str)
+        except json.JSONDecodeError:
+            # If JSON parsing fails, treat as string
+            return value_str
+    
+    def _format_output(self, value: Any) -> str:
+        """Format a value for display"""
+        if value is None:
+            return "null"
+        elif isinstance(value, dict) and "_link" in value:
+            return f"Link -> {value['_link']}"
+        else:
+            return json.dumps(value, indent=2)
+    
+    def _execute_command(self, command: str) -> bool:
+        """Execute a single command. Returns False if should exit."""
+        parts = command.strip().split()
+        if not parts:
+            return True
+        
+        cmd = parts[0].lower()
+        
+        try:
+            if cmd == "help":
+                self._show_help()
+            elif cmd == "quit" or cmd == "exit":
+                return False
+            elif cmd == "get":
+                if len(parts) < 2:
+                    print("Usage: get <key> [link_depth]")
+                    return True
+                
+                key = parts[1]
+                link_depth = None
+                if len(parts) > 2:
                     try:
-                        type_arg_index = parts.index('--type')
-                        if type_arg_index + 1 >= len(parts):
-                            print(
-                                "Error: --type argument requires a value (int, text, null).")
-                            continue
+                        link_depth = int(parts[2])
+                    except ValueError:
+                        print("Link depth must be an integer")
+                        return True
+                
+                result = self.client.get(key, link_depth)
+                print(self._format_output(result))
+            
+            elif cmd == "set":
+                if len(parts) < 3:
+                    print("Usage: set <key> <value>")
+                    return True
+                
+                key = parts[1]
+                value_str = " ".join(parts[2:])
+                value = self._parse_value(value_str)
+                
+                self.client.set(key, value)
+                print(f"Set {key} = {self._format_output(value)}")
+            
+            elif cmd == "delete" or cmd == "del":
+                if len(parts) < 2:
+                    print("Usage: delete <key>")
+                    return True
+                
+                key = parts[1]
+                self.client.delete(key)
+                print(f"Deleted {key}")
+            
+            elif cmd == "link":
+                if len(parts) < 3:
+                    print("Usage: link <key> <target_key>")
+                    return True
+                
+                key = parts[1]
+                target_key = parts[2]
+                link_value = {"_link": target_key}
+                
+                self.client.set(key, link_value)
+                print(f"Created link {key} -> {target_key}")
+            
+            else:
+                print(f"Unknown command: {cmd}. Type 'help' for available commands.")
+        
+        except CrabDBError as e:
+            print(f"Error: {e}")
+        except Exception as e:
+            print(f"Unexpected error: {e}")
+        
+        return True
+    
+    def _show_help(self):
+        """Show help information"""
+        print("""
+CrabDB Client Commands:
 
-                        cmd_type = parts[type_arg_index + 1].lower()
-                        if cmd_type not in DATA_TYPE_MAP:
-                            print(f"Error: Invalid type '{cmd_type}'. Must be int, text, null, list, map, or link.")
-                            continue
+  get <key> [link_depth]    - Get value by key, optionally resolve links
+  set <key> <value>         - Set key to value (JSON format supported)
+  delete <key>              - Delete key
+  link <key> <target_key>   - Create a link from key to target_key
+  help                      - Show this help
+  quit/exit                 - Exit the client
 
-                        # Ensure enough parts for key and value before --type
-                        # e.g., ['set', 'key', 'value', '--type', 'text'] => parts[1] is key, parts[2] is value
-                        if type_arg_index < 2:
-                            print(
-                                "Error: Invalid format for set. Usage: set <key> <value> --type <type>")
-                            continue
-
-                        key = parts[1]
-                        # Join all parts between the key and '--type' as the value
-                        value = ' '.join(parts[2:type_arg_index])
-
-                        value_type_code = DATA_TYPE_MAP[cmd_type]
-
-                        if value_type_code == TYPE_NULL:
-                            value_to_send = ''  # Value string is ignored for Null type
-                        else:
-                            value_to_send = value
-
-                        payload = construct_set_payload(
-                            key, value_to_send, value_type_code)
-                        print(f"Sending SET request for key='{key}'...")
-                        response = execute_command_on_socket(
-                            db_socket, payload)
-                        print("--- Server Response ---")
-                        print(response)
-
-                    except ValueError as ve:
-                        print(f"Error parsing set command: {ve}")
-                    except IndexError:
-                        print(
-                            "Error: Invalid format for set. Usage: set <key> <value> --type <type>")
-                    except Exception as e:
-                        print(f"An unexpected error occurred during set: {e}")
-
-                elif command == 'get':
-                    if db_socket is None:
-                        print(
-                            "Error: Not connected to the database. Use 'connect' first.")
+Examples:
+  set user1 "John Doe"
+  set user2 {"name": "Jane", "age": 30}
+  set numbers [1, 2, 3, 4, 5]
+  link current_user user1
+  get current_user 1        - Get with link resolution depth 1
+  delete user1
+        """)
+    
+    def run_interactive(self):
+        """Run in interactive mode"""
+        print("CrabDB Interactive Client")
+        print("Type 'help' for commands or 'quit' to exit")
+        print("Press Ctrl+C to exit gracefully")
+        
+        try:
+            self.client.connect()
+            print(f"Connected to {self.client.host}:{self.client.port}")
+        except CrabDBError as e:
+            print(f"Failed to connect: {e}")
+            return 1
+        
+        try:
+            while self.running:
+                try:
+                    command = input("crabdb> ").strip()
+                    if not command:
                         continue
-
-                    if len(parts) < 2:
-                        print("Usage: get <key> [--resolve-links <depth>]")
-                        continue
-
-                    key = parts[1]
                     
-                    # Check for --resolve-links parameter
-                    link_resolution_depth = None
-                    if len(parts) >= 4 and parts[2] == '--resolve-links':
-                        try:
-                            link_resolution_depth = int(parts[3])
-                            if link_resolution_depth < 0 or link_resolution_depth > 255:
-                                print("Error: Link resolution depth must be between 0 and 255")
-                                continue
-                        except ValueError:
-                            print("Error: Link resolution depth must be a valid integer")
-                            continue
-                    elif len(parts) > 2:
-                        print("Usage: get <key> [--resolve-links <depth>]")
-                        continue
-                    
-                    if link_resolution_depth is not None:
-                        payload = construct_get_payload_with_params(key, link_resolution_depth)
-                        print(f"Sending GET request for key='{key}' with link resolution depth={link_resolution_depth}...")
-                    else:
-                        payload = construct_get_payload(key)
-                        print(f"Sending GET request for key='{key}'...")
-                    
-                    response = execute_command_on_socket(db_socket, payload)
-                    print("--- Server Response ---")
-                    print(response)
-
-                elif command == 'delete':
-                    if db_socket is None:
-                        print(
-                            "Error: Not connected to the database. Use 'connect' first.")
-                        continue
-
-                    if len(parts) != 2:
-                        print("Usage: delete <key>")
-                        continue
-
-                    key = parts[1]
-                    payload = construct_delete_payload(key)
-                    print(f"Sending DELETE request for key='{key}'...")
-                    response = execute_command_on_socket(db_socket, payload)
-                    print("--- Server Response ---")
-                    print(response)
-
-                elif command == 'close':
-                    if db_socket is None:
-                        print("Error: Not connected to the database.")
-                        continue
-
-                    print("Sending close request to server...")
-                    if send_close_request(db_socket):
-                        try:
-                            db_socket.close()
-                        except:
-                            pass
-                        db_socket = None
-                        print("Connection closed.")
-                    else:
-                        print("Failed to send close request properly.")
-
-                else:
-                    print(f"Unknown command: '{command}'.")
-
-            except EOFError:  # User pressed Ctrl+D
-                print("\nExiting interactive mode.")
-                break
-            except Exception as e:
-                print(f"An unhandled error occurred in interactive mode: {e}")
-    finally:
-        # Ensure the socket is closed when interactive mode exits for any reason
-        if db_socket:
-            try:
-                print("Sending close request to server before exit...")
-                send_close_request(db_socket)
-                db_socket.close()
-                print("Database connection closed.")
-            except socket.error as e:
-                print(f"Error closing socket on exit: {e}", file=sys.stderr)
+                    if not self._execute_command(command):
+                        break
+                
+                except EOFError:
+                    # Handle Ctrl+D
+                    print("\nGoodbye!")
+                    break
+                except KeyboardInterrupt:
+                    # This will be handled by the signal handler
+                    continue
+        
+        finally:
+            self.client.disconnect()
+        
+        return 0
+    
+    def run_single_command(self, command: str) -> int:
+        """Run a single command and exit"""
+        try:
+            self.client.connect()
+        except CrabDBError as e:
+            print(f"Failed to connect: {e}")
+            return 1
+        
+        try:
+            self._execute_command(command)
+            return 0
+        except Exception as e:
+            print(f"Error: {e}")
+            return 1
+        finally:
+            self.client.disconnect()
 
 
 def main():
-    """
-    Main function to parse command-line arguments and execute commands.
-    Supports single command execution or interactive mode.
-    """
-    parser = argparse.ArgumentParser(
-        description="CLI client for a custom TCP database.",
-        formatter_class=argparse.RawTextHelpFormatter
-    )
-    parser.add_argument('--host', default='127.0.0.1',
-                        help='The server host address (default: 127.0.0.1).\n'
-                             'Used for single commands or as initial host for interactive mode.')
-    parser.add_argument('--port', type=int, default=7227,
-                        help='The server port (default: 7227).\n'
-                             'Used for single commands or as initial port for interactive mode.')
-
-    parser.add_argument('--interactive', '-i', action='store_true',
-                        help='Run the client in interactive mode.\n'
-                             'Ignores other command-line arguments if present.')
-
-    subparsers = parser.add_subparsers(
-        dest='command', help='Available single commands.\n'
-        'Use --interactive for interactive mode.')
-
-    # --- Parser for the "set" command ---
-    parser_set = subparsers.add_parser(
-        'set', help='Set a key-value pair in the database.')
-    parser_set.add_argument('key', help='The key to set.')
-    parser_set.add_argument(
-        'value', help='The value to associate with the key. For "null" type, the value will be ignored.')
-    parser_set.add_argument(
-        '--type', choices=['int', 'text', 'null', 'list', 'map', 'link'], required=True, 
-        help='The data type of the value. Use "link" to reference another key.')
-
-    # --- Parser for the "get" command ---
-    parser_get = subparsers.add_parser(
-        'get', help='Get a value by its key from the database.')
-    parser_get.add_argument('key', help='The key to retrieve.')
-    parser_get.add_argument('--resolve-links', type=int, metavar='DEPTH',
-                           help='Enable link resolution with maximum depth (0-255). '
-                                'Links will be automatically resolved to their target objects.')
-
-    # --- Parser for the "delete" command ---
-    parser_delete = subparsers.add_parser(
-        'delete', help='Delete a key-value pair from the database.')
-    parser_delete.add_argument('key', help='The key to delete.')
-
-    # --- Parser for the "updated_time" command ---
-    parser_updated_time = subparsers.add_parser(
-        'updated_time', help='Get the updated timestamp for a key from the database.')
-    parser_updated_time.add_argument(
-        'key', help='The key to get the timestamp for.')
-
-    # --- Parser for the "close" command ---
-    parser_close = subparsers.add_parser(
-        'close', help='Send a close/shutdown request to the server.')
-
+    """Main entry point"""
+    parser = argparse.ArgumentParser(description="CrabDB Python Client")
+    parser.add_argument("--host", default="localhost", help="CrabDB server host")
+    parser.add_argument("--port", type=int, default=7227, help="CrabDB server port")
+    parser.add_argument("--command", "-c", help="Execute single command and exit")
+    
     args = parser.parse_args()
-
-    if args.interactive:
-        # If interactive flag is present, ignore any other command and go interactive
-        interactive_mode(args.host, args.port)
-    elif args.command:  # A specific command was provided (not interactive)
-        payload = b''
-        try:
-            if args.command == 'set':
-                print(f"Executing SET: key='{args.key}', value='{
-                      args.value}', type='{args.type}'")
-
-                value_type_code = DATA_TYPE_MAP[args.type]
-
-                if value_type_code == TYPE_NULL:
-                    value_to_send = ''
-                else:
-                    value_to_send = args.value
-
-                payload = construct_set_payload(
-                    args.key, value_to_send, value_type_code)
-            elif args.command == 'get':
-                if hasattr(args, 'resolve_links') and args.resolve_links is not None:
-                    print(f"Executing GET: key='{args.key}' with link resolution depth={args.resolve_links}")
-                    payload = construct_get_payload_with_params(args.key, args.resolve_links)
-                else:
-                    print(f"Executing GET: key='{args.key}'")
-                    payload = construct_get_payload(args.key)
-            elif args.command == 'delete':
-                print(f"Executing DELETE: key='{args.key}'")
-                payload = construct_delete_payload(args.key)
-            elif args.command == 'close':
-                print("Executing CLOSE: sending shutdown request to server")
-                payload = construct_close_payload()
-
-            if payload:
-                print(f"Sending {len(payload)} bytes to {
-                      args.host}:{args.port}")
-                # Use execute_command_once for single command execution
-                parsed_response = execute_command_once(
-                    args.host, args.port, payload)
-                print("\n--- Server Response ---")
-                print(parsed_response)
-        except (ValueError, socket.error) as e:
-            print(f"Error during command execution: {e}", file=sys.stderr)
-            sys.exit(1)
-        except Exception as e:
-            print(f"An unexpected error occurred: {e}", file=sys.stderr)
-            sys.exit(1)
+    
+    cli = CrabDBCLI(args.host, args.port)
+    
+    if args.command:
+        return cli.run_single_command(args.command)
     else:
-        # If no interactive flag and no command specified (e.g., just `./cli.py`),
-        # print usage and suggest interactive mode.
-        parser.print_help()
-        print("\nTip: Use '--interactive' or '-i' to enter interactive mode.")
+        return cli.run_interactive()
 
 
-def _serialize_object(value):
-    """
-    Serialize a single JSON value to CrabDB object format.
-    Handles null, int, string, list, and map (dict) values recursively.
-    """
-    if value is None:
-        # Serialize null
-        return struct.pack('>B', TYPE_NULL)
-    elif isinstance(value, int):
-        # Serialize int
-        return struct.pack('>B', TYPE_INT) + struct.pack('>q', value)
-    elif isinstance(value, str):
-        # Serialize text
-        text_bytes = value.encode('utf-8')
-        return (
-            struct.pack('>B', TYPE_TEXT) +
-            struct.pack('>H', len(text_bytes)) +
-            text_bytes
-        )
-    elif isinstance(value, list):
-        # Serialize list recursively
-        serialized_objects = []
-        for item in value:
-            serialized_objects.append(_serialize_object(item))
-
-        serialized_data = b''.join(serialized_objects)
-        return (
-            struct.pack('>B', TYPE_LIST) +
-            struct.pack('>H', len(value)) +
-            serialized_data
-        )
-    elif isinstance(value, dict):
-        # Serialize map recursively
-        serialized_fields = []
-        for key, val in value.items():
-            if not isinstance(key, str):
-                raise ValueError("Map keys must be strings")
-
-            # Serialize field name
-            key_bytes = key.encode('utf-8')
-            field_data = struct.pack('>H', len(key_bytes)) + key_bytes
-
-            # Serialize field value recursively
-            field_data += _serialize_object(val)
-
-            serialized_fields.append(field_data)
-
-        serialized_data = b''.join(serialized_fields)
-        return (
-            struct.pack('>B', TYPE_MAP) +
-            struct.pack('>H', len(value)) +
-            serialized_data
-        )
-    else:
-        raise ValueError(f"Unsupported JSON value type: {type(value)}")
-
-
-def _serialize_list(value_str):
-    """
-    Serialize a list from JSON-like string format.
-    Supports nested structures: [1, "hello", null, [1, 2], {"key": "value"}]
-    """
-    import json
-    try:
-        # Parse as JSON array
-        items = json.loads(value_str)
-        if not isinstance(items, list):
-            raise ValueError("List value must be a JSON array")
-
-        serialized_objects = []
-        for item in items:
-            serialized_objects.append(_serialize_object(item))
-
-        # Combine all serialized objects
-        serialized_data = b''.join(serialized_objects)
-
-        # Return count + data
-        return struct.pack('>H', len(items)) + serialized_data
-
-    except json.JSONDecodeError:
-        raise ValueError("List value must be valid JSON array format")
-
-
-def _serialize_map(value_str):
-    """
-    Serialize a map from JSON-like string format.
-    Supports nested structures: {"key1": value1, "nested": {"inner": "value"}, "list": [1, 2, 3]}
-    """
-    import json
-    try:
-        # Parse as JSON object
-        obj = json.loads(value_str)
-        if not isinstance(obj, dict):
-            raise ValueError("Map value must be a JSON object")
-
-        serialized_fields = []
-        for key, value in obj.items():
-            if not isinstance(key, str):
-                raise ValueError("Map keys must be strings")
-
-            # Serialize field name
-            key_bytes = key.encode('utf-8')
-            field_data = struct.pack('>H', len(key_bytes)) + key_bytes
-
-            # Serialize field value using the generic object serializer
-            field_data += _serialize_object(value)
-
-            serialized_fields.append(field_data)
-
-        # Combine all serialized fields
-        serialized_data = b''.join(serialized_fields)
-
-        # Return field count + data
-        return struct.pack('>H', len(obj)) + serialized_data
-
-    except json.JSONDecodeError:
-        raise ValueError("Map value must be valid JSON object format")
-
-
-def _deserialize_object(data, cursor):
-    """
-    Deserialize a single object from binary data.
-    Handles all CrabDB types recursively: null, int, text, list, map.
-    Returns (value, new_cursor_position).
-    """
-    if cursor >= len(data):
-        raise ValueError("Incomplete object data")
-
-    # Read type ID
-    type_id = data[cursor]
-    cursor += 1
-
-    if type_id == TYPE_NULL:
-        return None, cursor
-    elif type_id == TYPE_INT:
-        if cursor + 8 > len(data):
-            raise ValueError("Incomplete int data")
-        value = struct.unpack('>q', data[cursor:cursor+8])[0]
-        return value, cursor + 8
-    elif type_id == TYPE_TEXT:
-        if cursor + 2 > len(data):
-            raise ValueError("Incomplete text length")
-        text_len = struct.unpack('>H', data[cursor:cursor+2])[0]
-        cursor += 2
-        if cursor + text_len > len(data):
-            raise ValueError("Incomplete text data")
-        text_value = data[cursor:cursor+text_len].decode('utf-8')
-        return text_value, cursor + text_len
-    elif type_id == TYPE_LIST:
-        if cursor + 2 > len(data):
-            raise ValueError("Incomplete list count")
-        list_count = struct.unpack('>H', data[cursor:cursor+2])[0]
-        cursor += 2
-        return _deserialize_list(data, cursor, list_count)
-    elif type_id == TYPE_MAP:
-        if cursor + 2 > len(data):
-            raise ValueError("Incomplete map field count")
-        field_count = struct.unpack('>H', data[cursor:cursor+2])[0]
-        cursor += 2
-        return _deserialize_map(data, cursor, field_count)
-    elif type_id == TYPE_LINK:
-        if cursor + 2 > len(data):
-            raise ValueError("Incomplete link length")
-        link_len = struct.unpack('>H', data[cursor:cursor+2])[0]
-        cursor += 2
-        if cursor + link_len > len(data):
-            raise ValueError("Incomplete link data")
-        link_key = data[cursor:cursor+link_len].decode('utf-8')
-        return f"Link -> '{link_key}'", cursor + link_len
-    else:
-        raise ValueError(f"Unsupported type ID: {type_id}")
-
-
-def _deserialize_list(data, cursor, count):
-    """Deserialize a list from binary data, supporting nested structures."""
-    items = []
-    for _ in range(count):
-        if cursor >= len(data):
-            raise ValueError("Incomplete list data")
-
-        # Deserialize object recursively
-        obj, cursor = _deserialize_object(data, cursor)
-        items.append(obj)
-
-    return items, cursor
-
-
-def _deserialize_map(data, cursor, field_count):
-    """Deserialize a map from binary data, supporting nested structures."""
-    fields = {}
-    for _ in range(field_count):
-        if cursor + 2 > len(data):
-            raise ValueError("Incomplete field name length in map")
-
-        # Read field name length
-        name_len = struct.unpack('>H', data[cursor:cursor+2])[0]
-        cursor += 2
-
-        # Read field name
-        if cursor + name_len > len(data):
-            raise ValueError("Incomplete field name in map")
-        field_name = data[cursor:cursor+name_len].decode('utf-8')
-        cursor += name_len
-
-        # Deserialize field value recursively
-        value, cursor = _deserialize_object(data, cursor)
-        fields[field_name] = value
-
-    return fields, cursor
-
-
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    sys.exit(main())

--- a/client/crabdb_client.py
+++ b/client/crabdb_client.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+CrabDB Python Client
+
+A Python client for interacting with CrabDB using the binary TCP protocol.
+"""
+
+import socket
+import struct
+import sys
+from typing import Optional, Union, List, Dict, Any
+from enum import IntEnum
+
+
+class DataType(IntEnum):
+    """CrabDB data types"""
+    NULL = 0
+    INT = 1
+    TEXT = 2
+    LIST = 3
+    MAP = 4
+    LINK = 5
+
+
+class CommandType(IntEnum):
+    """CrabDB command types"""
+    GET = 0
+    SET = 1
+    DELETE = 2
+    CLOSE = 255
+
+
+class ParameterType(IntEnum):
+    """CrabDB parameter types"""
+    LINK_RESOLUTION = 1
+
+
+class CrabDBError(Exception):
+    """Base exception for CrabDB client errors"""
+    pass
+
+
+class CrabDBClient:
+    """CrabDB client for TCP communication"""
+
+    def __init__(self, host: str = "localhost", port: int = 7227):
+        self.host = host
+        self.port = port
+        self.socket: Optional[socket.socket] = None
+        self.connected = False
+
+    def connect(self) -> None:
+        """Connect to the CrabDB server"""
+        try:
+            self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.socket.connect((self.host, self.port))
+            self.connected = True
+        except Exception as e:
+            raise CrabDBError(f"Failed to connect to {
+                              self.host}:{self.port}: {e}")
+
+    def disconnect(self) -> None:
+        """Disconnect from the CrabDB server"""
+        if self.socket and self.connected:
+            try:
+                # Send CLOSE command
+                self._send_command(CommandType.CLOSE, b"")
+            except:
+                pass  # Ignore errors during close
+            finally:
+                self.socket.close()
+                self.connected = False
+
+    def _send_command(self, command_type: CommandType, payload: bytes) -> bytes:
+        """Send a command and return the response"""
+        if not self.connected or not self.socket:
+            raise CrabDBError("Not connected to server")
+
+        # Build request: length (8 bytes) + command type (1 byte) + payload
+        request_data = struct.pack(">B", command_type) + payload
+        request_length = len(request_data)
+        request = struct.pack(">Q", request_length) + request_data
+
+        # Send request
+        self.socket.sendall(request)
+
+        # Read response length
+        response_length_data = self._recv_exact(8)
+        response_length = struct.unpack(">Q", response_length_data)[0]
+
+        # Read response data
+        response_data = self._recv_exact(response_length)
+
+        # Check for error response
+        if response_length == 1 and response_data[0] == 255:
+            raise CrabDBError("Server returned error")
+
+        return response_data
+
+    def _recv_exact(self, length: int) -> bytes:
+        """Receive exactly the specified number of bytes"""
+        data = b""
+        while len(data) < length:
+            chunk = self.socket.recv(length - len(data))
+            if not chunk:
+                raise CrabDBError("Connection closed unexpectedly")
+            data += chunk
+        return data
+
+    def _encode_key(self, key: str) -> bytes:
+        """Encode a key according to CrabDB format"""
+        key_bytes = key.encode('utf-8')
+        return struct.pack(">H", len(key_bytes)) + key_bytes
+
+    def _encode_text(self, text: str) -> bytes:
+        """Encode text according to CrabDB format"""
+        text_bytes = text.encode('utf-8')
+        return struct.pack(">H", len(text_bytes)) + text_bytes
+
+    def _encode_value(self, value: Any) -> bytes:
+        """Encode a value according to CrabDB format"""
+        if value is None:
+            return struct.pack(">B", DataType.NULL)
+        elif isinstance(value, int):
+            return struct.pack(">B", DataType.INT) + struct.pack(">q", value)
+        elif isinstance(value, str):
+            return struct.pack(">B", DataType.TEXT) + self._encode_text(value)
+        elif isinstance(value, list):
+            data = struct.pack(">BH", DataType.LIST, len(value))
+            for item in value:
+                # Include full type prefix for nested objects
+                data += self._encode_value(item)
+            return data
+        elif isinstance(value, dict):
+            if "_link" in value:  # Special case for link objects
+                link_key = value["_link"]
+                # Include full key format for links
+                return struct.pack(">B", DataType.LINK) + self._encode_key(link_key)
+            else:  # Regular map
+                data = struct.pack(">BH", DataType.MAP, len(value))
+                for field_name, field_value in value.items():
+                    field_name_bytes = field_name.encode('utf-8')
+                    data += struct.pack(">H", len(field_name_bytes)
+                                        ) + field_name_bytes
+                    # Include full type prefix for nested objects
+                    data += self._encode_value(field_value)
+                return data
+        else:
+            raise CrabDBError(f"Unsupported value type: {type(value)}")
+
+    def _decode_value(self, data: bytes, offset: int = 0) -> tuple[Any, int]:
+        """Decode a value from bytes, returning (value, new_offset)"""
+        if offset >= len(data):
+            raise CrabDBError("Unexpected end of data")
+
+        data_type = data[offset]
+        offset += 1
+
+        if data_type == DataType.NULL:
+            return None, offset
+        elif data_type == DataType.INT:
+            if offset + 8 > len(data):
+                raise CrabDBError("Insufficient data for int")
+            value = struct.unpack(">q", data[offset:offset + 8])[0]
+            return value, offset + 8
+        elif data_type == DataType.TEXT:
+            if offset + 2 > len(data):
+                raise CrabDBError("Insufficient data for text length")
+            text_length = struct.unpack(">H", data[offset:offset + 2])[0]
+            offset += 2
+            if offset + text_length > len(data):
+                raise CrabDBError("Insufficient data for text")
+            text = data[offset:offset + text_length].decode('utf-8')
+            return text, offset + text_length
+        elif data_type == DataType.LIST:
+            if offset + 2 > len(data):
+                raise CrabDBError("Insufficient data for list count")
+            count = struct.unpack(">H", data[offset:offset + 2])[0]
+            offset += 2
+            items = []
+            for _ in range(count):
+                item, offset = self._decode_value(data, offset)
+                items.append(item)
+            return items, offset
+        elif data_type == DataType.MAP:
+            if offset + 2 > len(data):
+                raise CrabDBError("Insufficient data for map field count")
+            field_count = struct.unpack(">H", data[offset:offset + 2])[0]
+            offset += 2
+            result = {}
+            for _ in range(field_count):
+                # Read field name
+                if offset + 2 > len(data):
+                    raise CrabDBError(
+                        "Insufficient data for field name length")
+                name_length = struct.unpack(">H", data[offset:offset + 2])[0]
+                offset += 2
+                if offset + name_length > len(data):
+                    raise CrabDBError("Insufficient data for field name")
+                field_name = data[offset:offset + name_length].decode('utf-8')
+                offset += name_length
+                # Read field value
+                field_value, offset = self._decode_value(data, offset)
+                result[field_name] = field_value
+            return result, offset
+        elif data_type == DataType.LINK:
+            if offset + 2 > len(data):
+                raise CrabDBError("Insufficient data for link key length")
+            key_length = struct.unpack(">H", data[offset:offset + 2])[0]
+            offset += 2
+            if offset + key_length > len(data):
+                raise CrabDBError("Insufficient data for link key")
+            key = data[offset:offset + key_length].decode('utf-8')
+            return {"_link": key}, offset + key_length
+        else:
+            raise CrabDBError(f"Unknown data type: {data_type}")
+
+    def get(self, key: str, link_resolution_depth: Optional[int] = None) -> Any:
+        """Get a value by key with optional link resolution"""
+        payload = self._encode_key(key)
+
+        # Add parameters if link resolution is requested
+        if link_resolution_depth is not None:
+            payload += struct.pack(">B", 1)  # Number of parameters
+            payload += struct.pack(">BB", ParameterType.LINK_RESOLUTION,
+                                   link_resolution_depth)
+        else:
+            payload += struct.pack(">B", 0)  # No parameters
+
+        response = self._send_command(CommandType.GET, payload)
+        value, _ = self._decode_value(response)
+        return value
+
+    def set(self, key: str, value: Any) -> None:
+        """Set a key-value pair"""
+        payload = self._encode_key(key)
+        value_data = self._encode_value(value)
+        payload += value_data
+
+        self._send_command(CommandType.SET, payload)
+
+    def delete(self, key: str) -> None:
+        """Delete a key"""
+        payload = self._encode_key(key)
+        self._send_command(CommandType.DELETE, payload)
+
+    def __enter__(self):
+        """Context manager entry"""
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit"""
+        self.disconnect()

--- a/client/test_client.py
+++ b/client/test_client.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Simple test script for CrabDB Python client
+"""
+
+from crabdb_client import CrabDBClient, CrabDBError
+
+
+def test_basic_operations():
+    """Test basic database operations"""
+    print("Testing CrabDB Python Client...")
+
+    try:
+        with CrabDBClient() as client:
+            print("✓ Connected to CrabDB")
+
+            # Test setting and getting different data types
+            test_cases = [
+                ("null_value", None),
+                ("int_value", 42),
+                ("text_value", "Hello, CrabDB!"),
+                ("list_value", [1, 2, "three", None]),
+                ("map_value", {"name": "Alice", "age": 30, "active": True}),
+            ]
+
+            for key, value in test_cases:
+                client.set(key, value)
+                retrieved = client.get(key)
+                assert retrieved == value, f"Mismatch for {
+                    key}: {retrieved} != {value}"
+                print(f"✓ {key}: {value}")
+
+            # Test link creation and resolution
+            client.set("user1", {"name": "Bob", "role": "admin"})
+            client.set("link_to_user", {"_link": "user1"})
+
+            # Get link without resolution
+            link_obj = client.get("link_to_user")
+            assert link_obj == {
+                "_link": "user1"}, f"Link object mismatch: {link_obj}"
+            print("✓ Link creation")
+
+            # Get link with resolution
+            resolved = client.get("link_to_user", 1)
+            expected = {"name": "Bob", "role": "admin"}
+            assert resolved == expected, f"Link resolution mismatch: {
+                resolved} != {expected}"
+            print("✓ Link resolution")
+
+            # Test deletion
+            client.delete("null_value")
+            result = client.get("null_value")
+            assert result is None, f"Expected None for deleted key, got: {result}"
+            print("✓ Deletion (returns None for non-existent keys)")
+
+            print("\nAll tests passed! 🎉")
+
+    except CrabDBError as e:
+        print(f"❌ CrabDB Error: {e}")
+        return False
+    except Exception as e:
+        print(f"❌ Unexpected error: {e}")
+        return False
+
+    return True
+
+
+if __name__ == "__main__":
+    success = test_basic_operations()
+    exit(0 if success else 1)

--- a/engine/src/link_resolver.rs
+++ b/engine/src/link_resolver.rs
@@ -1,69 +1,105 @@
 // Resolves Links between objects
 
-use object::types::{
-    link::Link,
-    list::{List, ListBuilder},
-    map::{Map, MapBuilder},
+use object::{
+    Key,
+    types::{
+        link::Link,
+        list::{List, ListBuilder},
+        map::{Map, MapBuilder},
+    },
 };
+use server::LinkResolution;
+use std::collections::HashSet;
 
-/// Resolves the links of an object and returns a new Object with the Links resolved
-/// It requires a reference to the storage to resolve the links
-pub fn resolve_links<T: storage::Store>(
-    object: object::Object,
-    storage: &T,
-) -> storage::StoreResult {
-    match object.kind() {
-        object::ObjectKind::List => resolve_list_links(object, storage),
-        object::ObjectKind::Map => resolve_map_links(object, storage),
-        object::ObjectKind::Link => resolve_link(object, storage),
-        // Int, Text, Null cannot contain links
-        _ => Ok(object),
-    }
+/// Manages link resolution
+pub struct LinkResolver<'a, T: storage::Store> {
+    /// The number of resolutions so far
+    // This cannot be a u8 since then it could never be greater than max_resolutions
+    num_resolutions: u16,
+    /// The max number of resolutions that can occur
+    max_resolutions: u8,
+    /// Links that have already been visited, used for cycle detection
+    visited: HashSet<Key>,
+    /// The storage medium used
+    storage: &'a T,
 }
 
-/// Resolve links for a List
-fn resolve_list_links<T: storage::Store>(
-    object: object::Object,
-    storage: &T,
-) -> storage::StoreResult {
-    // This is safe since the only way a list could get stored is if it is valid
-    // if something happend that made it not valid then we have a bigger problem
-    let list = unsafe { List::from_object_unchecked(object) };
-    let mut builder = ListBuilder::new(list.len());
-
-    for object in list {
-        let object = resolve_links(object, storage)?;
-        builder.add_item_no_increment(object);
+impl<'a, T: storage::Store> LinkResolver<'a, T> {
+    /// Creates a new LinkResolver
+    pub fn new(link_resolutions: LinkResolution, storage: &'a T) -> Self {
+        Self {
+            num_resolutions: 0,
+            max_resolutions: link_resolutions.max_resolutions(),
+            visited: HashSet::new(),
+            storage,
+        }
     }
 
-    Ok(builder.build().into())
-}
+    /// Resolves the links of an object and returns a new Object with the Links resolved
+    /// It requires a reference to the storage to resolve the links. If max resolutions is
+    /// reached or a cycle is detected the object as is will be returend
+    // TODO: should cycles cause an error?
+    pub fn resolve_links(&mut self, object: object::Object) -> storage::StoreResult {
+        if self.num_resolutions > self.max_resolutions as u16 {
+            return Ok(object);
+        }
 
-/// Resolve links for a Map
-fn resolve_map_links<T: storage::Store>(
-    object: object::Object,
-    storage: &T,
-) -> storage::StoreResult {
-    // This is safe since the only way a list could get stored is if it is valid
-    // if something happend that made it not valid then we have a bigger problem
-    let map = unsafe { Map::from_object_unchecked(object) };
-    let mut builder = MapBuilder::new(map.num_fields());
-
-    for (field_name, object) in map {
-        builder.add_field_no_increment(field_name.as_ref(), resolve_links(object, storage)?);
+        match object.kind() {
+            object::ObjectKind::List => self.resolve_list_links(object),
+            object::ObjectKind::Map => self.resolve_map_links(object),
+            object::ObjectKind::Link => self.resolve_link(object),
+            // Int, Text, Null cannot contain links
+            _ => Ok(object),
+        }
     }
 
-    Ok(builder.build().into())
-}
+    /// Resolve links for a List
+    fn resolve_list_links(&mut self, object: object::Object) -> storage::StoreResult {
+        // This is safe since the only way a list could get stored is if it is valid
+        // if something happend that made it not valid then we have a bigger problem
+        let list = unsafe { List::from_object_unchecked(object) };
+        let mut builder = ListBuilder::new(list.len());
 
-/// Resolve links for a Link
-fn resolve_link<T: storage::Store>(object: object::Object, storage: &T) -> storage::StoreResult {
-    // This is safe since the only way a link could get stored is if it is valid
-    // if something happend that made it not valid then we have a bigger problem
-    let link = unsafe { Link::from_object_unchecked(object) };
-    let key = link.into();
+        for object in list {
+            let object = self.resolve_links(object)?;
+            builder.add_item_no_increment(object);
+        }
 
-    let object = storage.retrieve(key)?;
-    // the object retrieve may also have links that need to be resolved
-    resolve_links(object, storage)
+        Ok(builder.build().into())
+    }
+
+    /// Resolve links for a Map
+    fn resolve_map_links(&mut self, object: object::Object) -> storage::StoreResult {
+        // This is safe since the only way a list could get stored is if it is valid
+        // if something happend that made it not valid then we have a bigger problem
+        let map = unsafe { Map::from_object_unchecked(object) };
+        let mut builder = MapBuilder::new(map.num_fields());
+
+        for (field_name, object) in map {
+            builder.add_field_no_increment(field_name.as_ref(), self.resolve_links(object)?);
+        }
+
+        Ok(builder.build().into())
+    }
+
+    /// Resolve links for a Link
+    fn resolve_link(&mut self, object: object::Object) -> storage::StoreResult {
+        // This is safe since the only way a link could get stored is if it is valid
+        // if something happend that made it not valid then we have a bigger problem
+        let link = unsafe { Link::from_object_unchecked(object) };
+        let key = link.into();
+
+        // I know there are a lot of .into()'s but they are zero cost... at least I think
+        if self.visited.contains(&key) {
+            // cycle detected early return
+            let link: Link = key.into();
+            return Ok(link.into());
+        }
+
+        let object = self.storage.retrieve(&key)?;
+        self.visited.insert(key);
+
+        // the object retrieve may also have links that need to be resolved
+        self.resolve_links(object)
+    }
 }

--- a/engine/src/link_resolver.rs
+++ b/engine/src/link_resolver.rs
@@ -2,6 +2,10 @@
 
 use object::types::{link::Link, list::List, map::Map};
 
+// TODO: I personally think there are a lot of things that can be done better here.
+// there are many memory allocations and I am still deciding if I like how
+// this code is structured but if it works for now its fine.
+
 /// Resolves the links of an object and returns a new Object with the Links resolved
 /// It requires a reference to the storage to resolve the links
 pub fn resolve_links<T: storage::Store>(
@@ -43,8 +47,13 @@ fn resolve_map_links<T: storage::Store>(
     // This is safe since the only way a list could get stored is if it is valid
     // if something happend that made it not valid then we have a bigger problem
     let map = unsafe { Map::from_object_unchecked(object) };
+    let mut records = Vec::with_capacity(map.num_fields() as usize);
 
-    todo!()
+    for (field_name, object) in map {
+        records.push((field_name, resolve_links(object, storage)?));
+    }
+
+    Ok(Map::from(records.as_slice()).into())
 }
 
 /// Resolve links for a Link

--- a/engine/src/link_resolver.rs
+++ b/engine/src/link_resolver.rs
@@ -1,6 +1,6 @@
 // Resolves Links between objects
 
-use object::Key;
+use object::types::{link::Link, list::List};
 
 /// Resolves the links of an object and returns a new Object with the Links resolved
 /// It requires a reference to the storage to resolve the links
@@ -9,29 +9,46 @@ pub fn resolve_links<T: storage::Store>(
     storage: &T,
 ) -> storage::StoreResult {
     match object.kind() {
-        object::ObjectKind::List => resolve_list_links(object.data(), storage),
-        object::ObjectKind::Map => resolve_map_links(object.data(), storage),
-        object::ObjectKind::Link => resolve_link(object.data(), storage),
+        object::ObjectKind::List => resolve_list_links(object, storage),
+        object::ObjectKind::Map => resolve_map_links(object, storage),
+        object::ObjectKind::Link => resolve_link(object, storage),
         // Int, Text, Null cannot contain links
         _ => Ok(object),
     }
 }
 
 /// Resolve links for a List
-fn resolve_list_links<T: storage::Store>(object_data: &[u8], storage: &T) -> storage::StoreResult {
-    todo!()
+fn resolve_list_links<T: storage::Store>(
+    object: object::Object,
+    storage: &T,
+) -> storage::StoreResult {
+    // This is safe since the only way a list could get stored is if it is valid
+    // if something happend that made it not valid then we have a bigger problem
+    let list = unsafe { List::from_object_unchecked(object) };
+    let mut objects = Vec::with_capacity(list.len() as usize);
+
+    for object in list {
+        let object = resolve_links(object, storage)?;
+        objects.push(object);
+    }
+
+    Ok(List::from(objects.as_slice()).into())
 }
 
 /// Resolve links for a Map
-fn resolve_map_links<T: storage::Store>(object_data: &[u8], storage: &T) -> storage::StoreResult {
+fn resolve_map_links<T: storage::Store>(
+    object: object::Object,
+    storage: &T,
+) -> storage::StoreResult {
     todo!()
 }
 
 /// Resolve links for a Link
-fn resolve_link<T: storage::Store>(object_data: &[u8], storage: &T) -> storage::StoreResult {
-    // This is safe since the only way a key could get stored is if it is valid
+fn resolve_link<T: storage::Store>(object: object::Object, storage: &T) -> storage::StoreResult {
+    // This is safe since the only way a link could get stored is if it is valid
     // if something happend that made it not valid then we have a bigger problem
-    let key = unsafe { Key::new_unchecked(object_data) };
+    let link = unsafe { Link::from_object_unchecked(object) };
+    let key = link.into();
 
     let object = storage.retrieve(key)?;
     // the object retrieve may also have links that need to be resolved

--- a/engine/src/link_resolver.rs
+++ b/engine/src/link_resolver.rs
@@ -1,10 +1,10 @@
 // Resolves Links between objects
 
-use object::types::{link::Link, list::List, map::Map};
-
-// TODO: I personally think there are a lot of things that can be done better here.
-// there are many memory allocations and I am still deciding if I like how
-// this code is structured but if it works for now its fine.
+use object::types::{
+    link::Link,
+    list::{List, ListBuilder},
+    map::{Map, MapBuilder},
+};
 
 /// Resolves the links of an object and returns a new Object with the Links resolved
 /// It requires a reference to the storage to resolve the links
@@ -29,14 +29,14 @@ fn resolve_list_links<T: storage::Store>(
     // This is safe since the only way a list could get stored is if it is valid
     // if something happend that made it not valid then we have a bigger problem
     let list = unsafe { List::from_object_unchecked(object) };
-    let mut objects = Vec::with_capacity(list.len() as usize);
+    let mut builder = ListBuilder::new(list.len());
 
     for object in list {
         let object = resolve_links(object, storage)?;
-        objects.push(object);
+        builder.add_item_no_increment(object);
     }
 
-    Ok(List::from(objects.as_slice()).into())
+    Ok(builder.build().into())
 }
 
 /// Resolve links for a Map
@@ -47,13 +47,13 @@ fn resolve_map_links<T: storage::Store>(
     // This is safe since the only way a list could get stored is if it is valid
     // if something happend that made it not valid then we have a bigger problem
     let map = unsafe { Map::from_object_unchecked(object) };
-    let mut records = Vec::with_capacity(map.num_fields() as usize);
+    let mut builder = MapBuilder::new(map.num_fields());
 
     for (field_name, object) in map {
-        records.push((field_name, resolve_links(object, storage)?));
+        builder.add_field_no_increment(field_name.as_ref(), resolve_links(object, storage)?);
     }
 
-    Ok(Map::from(records.as_slice()).into())
+    Ok(builder.build().into())
 }
 
 /// Resolve links for a Link

--- a/engine/src/link_resolver.rs
+++ b/engine/src/link_resolver.rs
@@ -1,6 +1,6 @@
 // Resolves Links between objects
 
-use object::types::{link::Link, list::List};
+use object::types::{link::Link, list::List, map::Map};
 
 /// Resolves the links of an object and returns a new Object with the Links resolved
 /// It requires a reference to the storage to resolve the links
@@ -40,6 +40,10 @@ fn resolve_map_links<T: storage::Store>(
     object: object::Object,
     storage: &T,
 ) -> storage::StoreResult {
+    // This is safe since the only way a list could get stored is if it is valid
+    // if something happend that made it not valid then we have a bigger problem
+    let map = unsafe { Map::from_object_unchecked(object) };
+
     todo!()
 }
 

--- a/engine/src/link_resolver.rs
+++ b/engine/src/link_resolver.rs
@@ -1,0 +1,39 @@
+// Resolves Links between objects
+
+use object::Key;
+
+/// Resolves the links of an object and returns a new Object with the Links resolved
+/// It requires a reference to the storage to resolve the links
+pub fn resolve_links<T: storage::Store>(
+    object: object::Object,
+    storage: &T,
+) -> storage::StoreResult {
+    match object.kind() {
+        object::ObjectKind::List => resolve_list_links(object.data(), storage),
+        object::ObjectKind::Map => resolve_map_links(object.data(), storage),
+        object::ObjectKind::Link => resolve_link(object.data(), storage),
+        // Int, Text, Null cannot contain links
+        _ => Ok(object),
+    }
+}
+
+/// Resolve links for a List
+fn resolve_list_links<T: storage::Store>(object_data: &[u8], storage: &T) -> storage::StoreResult {
+    todo!()
+}
+
+/// Resolve links for a Map
+fn resolve_map_links<T: storage::Store>(object_data: &[u8], storage: &T) -> storage::StoreResult {
+    todo!()
+}
+
+/// Resolve links for a Link
+fn resolve_link<T: storage::Store>(object_data: &[u8], storage: &T) -> storage::StoreResult {
+    // This is safe since the only way a key could get stored is if it is valid
+    // if something happend that made it not valid then we have a bigger problem
+    let key = unsafe { Key::new_unchecked(object_data) };
+
+    let object = storage.retrieve(key)?;
+    // the object retrieve may also have links that need to be resolved
+    resolve_links(object, storage)
+}

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 use storage::{Store, append_only_log::AppendOnlyLogStore, in_memory_store::InMemoryStore};
 use threadpool::ThreadPool;
 
+mod link_resolver;
+
 /// The port to listen on
 const PORT: u16 = 7227;
 

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -74,7 +74,7 @@ fn main() {
                         }
                     }
                     Command::Set(key, object) => storage.store(key, object),
-                    Command::Delete(key) => storage.remove(key),
+                    Command::Delete(key) => storage.remove(&key),
                     Command::Close => {
                         info!("Recieved close command. Terminating connection");
                         break;

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
                 trace!("Command recieved: {:?}", command);
 
                 let object = match command {
-                    Command::Get(key) => storage.retrieve(key),
+                    Command::Get(key, _) => storage.retrieve(key),
                     Command::Set(key, object) => storage.store(key, object),
                     Command::Delete(key) => storage.remove(key),
                     Command::Close => break,

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
                             error!("Error sending command: {e}");
                         };
                     }
-                    Err(_) => error!("Error occured saving object"),
+                    Err(e) => error!("Error occured saving object: {e:?}"),
                 }
             }
         });

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -32,6 +32,9 @@ fn main() {
         }
     };
 
+    info!("Loaded data from file");
+    info!("{:?}", storage);
+
     // Creating a threadpool
     let mut thread_pool = ThreadPool::default();
 
@@ -68,7 +71,7 @@ fn main() {
                         {
                             let mut link_resolver =
                                 LinkResolver::new(link_resolution, storage.as_ref());
-                            link_resolver.resolve_links(object)
+                            link_resolver.resolve(object)
                         } else {
                             object
                         }

--- a/object/Cargo.toml
+++ b/object/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+logging = { path = "../logging" }

--- a/object/README.md
+++ b/object/README.md
@@ -1,3 +1,92 @@
 # Object
 
-Cotains the definition of an object in the database as well as the built in data types for the database.
+Contains the definition of an object in the database as well as the built-in data types for CrabDB.
+
+## Overview
+
+The `object` crate provides CrabDB's type system, including serialization and deserialization of all supported data types. Each object knows its type and can be safely converted between binary and structured representations.
+
+## Supported Data Types
+
+CrabDB supports the following built-in data types:
+
+| Type ID | Type Name | Description | Storage Format |
+|---------|-----------|-------------|----------------|
+| `0` | **Null** | Represents no value | No data |
+| `1` | **Int** | 64-bit signed integer | 8-byte big-endian |
+| `2` | **Text** | UTF-8 string | 2-byte length + string data |
+| `3` | **List** | Ordered collection of objects | 2-byte count + serialized objects |
+| `4` | **Map** | Key-value mapping (string keys) | 2-byte field count + field entries |
+| `5` | **Link** | Reference to another object by key | Same format as Key |
+
+## Key Features
+
+- **Type Safety**: Each object carries its type information
+- **Recursive Structures**: Lists and Maps can contain any other objects, including nested Lists and Maps
+- **Link References**: Link type enables object relationships and references
+- **Binary Serialization**: Efficient binary format for network transmission and storage
+- **Zero-Copy Deserialization**: Minimal memory allocation during parsing
+
+## Core Components
+
+### Object
+The main `Object` struct represents any value in the database:
+- Stores type information (`ObjectKind`)
+- Contains serialized binary data
+- Provides serialization/deserialization methods
+
+### Key
+Keys identify objects in the database:
+- UTF-8 encoded strings with length prefix
+- Used for object storage and Link references
+- Consistent binary format across the system
+
+### ObjectKind
+Enum representing all supported data types:
+- Used for type checking and dispatch
+- Convertible to/from binary type IDs
+- Enables safe type-specific operations
+
+## Usage Examples
+
+```rust
+use object::{Object, ObjectKind, Key};
+
+// Create objects of different types
+let null_obj = Object::null();
+let int_obj = Object::from(42i64);
+let text_obj = Object::from("Hello, World!");
+
+// Serialize for storage/transmission
+let bytes = int_obj.serialize();
+
+// Deserialize from binary data
+let (restored_obj, remaining) = Object::deserialize(&bytes)?;
+
+// Type checking
+match restored_obj.kind() {
+    ObjectKind::Int => println!("It's an integer!"),
+    ObjectKind::Text => println!("It's text!"),
+    _ => println!("It's something else!"),
+}
+```
+
+## Link Type and References
+
+The Link type enables creating relationships between objects:
+
+```rust
+// Create a link to another object
+let target_key = Key::from("user:123");
+let link_obj = Object::from(Link::from(target_key));
+
+// Links can be resolved by the engine when retrieving objects
+// This enables building complex data relationships
+```
+
+## Binary Protocol Integration
+
+This crate integrates seamlessly with CrabDB's binary protocol:
+- Objects serialize to the exact format expected by the network protocol
+- Keys use the same format for object identification and Link references
+- Type IDs match the protocol specification exactly

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -23,6 +23,8 @@ const KEY_LEN_NUM_BYTES: usize = std::mem::size_of::<KeyLen>();
 
 /// The value under which an object is stored in the database
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
+// TODO: Currently key stores its length as well which seems a bit redundent but is used for the Link type
+// this should possibly be changed and new intermediary type created since now an extra 2 bytes per key is wasted
 pub struct Key(Box<[u8]>); // we don't care about the capcity
 
 impl Key {

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -5,6 +5,16 @@ use types::{int::Int, list::List, map::Map, null::Null, text::Text};
 
 pub mod types;
 
+/// Convert a slice to a number
+#[macro_export]
+macro_rules! slice_to_num {
+    ($t:ty, $bytes:expr) => {{
+        let mut arr = [0u8; ::std::mem::size_of::<$t>()];
+        arr.copy_from_slice($bytes);
+        <$t>::from_be_bytes(arr)
+    }};
+}
+
 /// The data type used to store the key length
 type KeyLen = u16;
 /// The number of bytes the key length requires
@@ -34,9 +44,7 @@ impl Key {
             // making sure there is enough data
             Err(ObjectError)
         } else {
-            let mut buffer = [0; KEY_LEN_NUM_BYTES];
-            buffer.copy_from_slice(&bytes[..KEY_LEN_NUM_BYTES]);
-            let key_len = KeyLen::from_be_bytes(buffer) as usize;
+            let key_len = slice_to_num!(KeyLen, &bytes[..KEY_LEN_NUM_BYTES]) as usize;
 
             if key_len > 0 {
                 let key = &bytes[KEY_LEN_NUM_BYTES..key_len + KEY_LEN_NUM_BYTES];

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -73,7 +73,7 @@ impl fmt::Display for ObjectError {
 impl error::Error for ObjectError {}
 
 /// The types of Objects that can be stored in the database
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum ObjectKind {
     /// This represents no item
@@ -126,6 +126,16 @@ impl Object {
             kind: ObjectKind::Null,
             data: Box::new([]),
         }
+    }
+
+    /// Get an Object's kind
+    pub fn kind(&self) -> ObjectKind {
+        self.kind
+    }
+
+    /// Get the raw data of the object
+    pub fn data(&self) -> &[u8] {
+        &self.data
     }
 
     /// Turn an Object into raw bytes

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -61,13 +61,8 @@ impl Key {
     }
 
     /// Converts a key to bytes
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(KEY_LEN_NUM_BYTES + self.0.len());
-        let mut buffer = [0; KEY_LEN_NUM_BYTES];
-        buffer.copy_from_slice(&(self.0.len() as u16).to_be_bytes());
-        bytes.extend_from_slice(&buffer);
-        bytes.extend_from_slice(&self.0);
-        bytes
+    pub fn to_bytes(&self) -> &[u8] {
+        self.0.as_ref()
     }
 }
 

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -1,5 +1,6 @@
 use crate::types::link::Link;
 use core::error;
+use logging::trace;
 use std::fmt;
 use types::{int::Int, list::List, map::Map, null::Null, text::Text};
 
@@ -47,7 +48,7 @@ impl Key {
             let key_len = slice_to_num!(KeyLen, &bytes[..KEY_LEN_NUM_BYTES]) as usize;
 
             if key_len > 0 {
-                let key = &bytes[KEY_LEN_NUM_BYTES..key_len + KEY_LEN_NUM_BYTES];
+                let key = &bytes[..key_len + KEY_LEN_NUM_BYTES];
 
                 Ok((key, &bytes[key_len + KEY_LEN_NUM_BYTES..]))
             } else {

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -128,6 +128,11 @@ pub struct Object {
 }
 
 impl Object {
+    /// Create a new Object from an ObjectKind and the raw data. The raw data is not checked so this can lead to UB.
+    pub unsafe fn new_unchecked(kind: ObjectKind, data: Box<[u8]>) -> Self {
+        Self { kind, data }
+    }
+
     /// Creates a null object
     pub fn null() -> Self {
         Self {

--- a/object/src/types.rs
+++ b/object/src/types.rs
@@ -1,4 +1,5 @@
 pub mod int;
+pub mod link;
 pub mod list;
 pub mod map;
 pub mod null;

--- a/object/src/types/int.rs
+++ b/object/src/types/int.rs
@@ -7,7 +7,7 @@ const INTERNAL_INT_SIZE: usize = std::mem::size_of::<InternalInt>();
 
 /// The number data type that is stored in the database
 /// it is backed by a signed 64 bit integer
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Int;
 
 impl Int {

--- a/object/src/types/int.rs
+++ b/object/src/types/int.rs
@@ -1,4 +1,4 @@
-use crate::ObjectError;
+use crate::{Object, ObjectError, ObjectKind};
 
 /// The internal type used to represent an int
 type InternalInt = i64;
@@ -8,9 +8,22 @@ const INTERNAL_INT_SIZE: usize = std::mem::size_of::<InternalInt>();
 /// The number data type that is stored in the database
 /// it is backed by a signed 64 bit integer
 #[derive(Debug)]
-pub struct Int;
+pub struct Int(Box<[u8]>);
 
 impl Int {
+    /// Get the stored number
+    pub fn inner(&self) -> InternalInt {
+        let mut num = [0; INTERNAL_INT_SIZE];
+        num.copy_from_slice(&self.0[..INTERNAL_INT_SIZE]);
+
+        InternalInt::from_be_bytes(num)
+    }
+
+    /// Create an Int from an Object without verifying if it is valid (this method does not check the object_kind field)
+    pub unsafe fn from_object_unchecked(object: Object) -> Self {
+        Self(object.data)
+    }
+
     /// Validate int data and extract the consumed portion
     /// Int objects are exactly 8 bytes (i64 in big-endian)
     pub fn validate_and_extract(bytes: &[u8]) -> Result<(&[u8], &[u8]), ObjectError> {
@@ -19,6 +32,27 @@ impl Int {
         } else {
             let (int_bytes, remaining) = bytes.split_at(INTERNAL_INT_SIZE);
             Ok((int_bytes, remaining))
+        }
+    }
+}
+
+impl From<Int> for Object {
+    fn from(value: Int) -> Self {
+        Self {
+            kind: ObjectKind::Int,
+            data: value.0,
+        }
+    }
+}
+
+impl TryFrom<Object> for Int {
+    type Error = ObjectError;
+
+    fn try_from(value: Object) -> Result<Self, Self::Error> {
+        if value.kind() == ObjectKind::Int {
+            Ok(unsafe { Self::from_object_unchecked(value) })
+        } else {
+            Err(ObjectError)
         }
     }
 }

--- a/object/src/types/link.rs
+++ b/object/src/types/link.rs
@@ -1,0 +1,13 @@
+use crate::{Key, ObjectError};
+
+/// Represents a map (mapping of field names to objects) in the database
+#[derive(Debug)]
+pub struct Link;
+
+impl Link {
+    /// Validate link data and extract the consumed portion
+    /// Link format: same as Key
+    pub fn validate_and_extract(bytes: &[u8]) -> Result<(&[u8], &[u8]), ObjectError> {
+        Key::validate_and_extract(bytes)
+    }
+}

--- a/object/src/types/link.rs
+++ b/object/src/types/link.rs
@@ -1,13 +1,39 @@
-use crate::{Key, ObjectError};
+use crate::{Key, Object, ObjectError, ObjectKind};
 
 /// Represents a map (mapping of field names to objects) in the database
 #[derive(Debug)]
-pub struct Link;
+pub struct Link(Box<[u8]>);
 
 impl Link {
+    /// Create an Int from an Object without verifying if it is valid (this method does not check the object_kind field)
+    pub unsafe fn from_object_unchecked(object: Object) -> Self {
+        Self(object.data)
+    }
+
     /// Validate link data and extract the consumed portion
     /// Link format: same as Key
     pub fn validate_and_extract(bytes: &[u8]) -> Result<(&[u8], &[u8]), ObjectError> {
         Key::validate_and_extract(bytes)
+    }
+}
+
+impl From<Link> for Object {
+    fn from(value: Link) -> Self {
+        Self {
+            kind: ObjectKind::Int,
+            data: value.0,
+        }
+    }
+}
+
+impl TryFrom<Object> for Link {
+    type Error = ObjectError;
+
+    fn try_from(value: Object) -> Result<Self, Self::Error> {
+        if value.kind() == ObjectKind::Link {
+            Ok(unsafe { Self::from_object_unchecked(value) })
+        } else {
+            Err(ObjectError)
+        }
     }
 }

--- a/object/src/types/link.rs
+++ b/object/src/types/link.rs
@@ -37,3 +37,15 @@ impl TryFrom<Object> for Link {
         }
     }
 }
+
+impl From<Link> for Key {
+    fn from(value: Link) -> Self {
+        Self(value.0)
+    }
+}
+
+impl From<Key> for Link {
+    fn from(value: Key) -> Self {
+        Self(value.0)
+    }
+}

--- a/object/src/types/list.rs
+++ b/object/src/types/list.rs
@@ -126,12 +126,13 @@ impl ListBuilder {
     }
 
     /// Adds a field to the MapBuilder but does not increment the field_count. It requires the field_name (with the prefixed length) as well as the Object
+    // TODO: Should this method be unsafe since if you don't know what you are doing bad things can happen
     pub fn add_item_no_increment(&mut self, object: Object) {
         self.data.extend(object.serialize());
     }
 
     /// Adds a field to the MapBuilder. It requires the field_name (with the prefixed length) as well as the Object
-    pub fn add_ite(&mut self, object: Object) {
+    pub fn add_item(&mut self, object: Object) {
         self.add_item_no_increment(object);
         self.len += 1;
     }

--- a/object/src/types/list.rs
+++ b/object/src/types/list.rs
@@ -1,4 +1,4 @@
-use crate::{Object, ObjectError, ObjectKind};
+use crate::{Object, ObjectError, ObjectKind, slice_to_num};
 
 /// The data type used to store the length of List in the payload
 type ListLen = u16;
@@ -12,10 +12,7 @@ pub struct List(Box<[u8]>);
 impl List {
     /// Get the Len of the list
     pub fn len(&self) -> ListLen {
-        let mut len = [0; LIST_LEN_NUM_BYTES];
-        len.copy_from_slice(&self.0[..LIST_LEN_NUM_BYTES]);
-
-        ListLen::from_be_bytes(len)
+        slice_to_num!(ListLen, &self.0[..LIST_LEN_NUM_BYTES])
     }
 
     /// Create an Int from an Object without verifying if it is valid (this method does not check the object_kind field)
@@ -31,9 +28,7 @@ impl List {
         }
 
         // Extract the list length
-        let mut buffer = [0; LIST_LEN_NUM_BYTES];
-        buffer.copy_from_slice(&bytes[..LIST_LEN_NUM_BYTES]);
-        let list_len = ListLen::from_be_bytes(buffer) as usize;
+        let list_len = slice_to_num!(ListLen, &bytes[..LIST_LEN_NUM_BYTES]) as usize;
 
         let mut remaining_bytes = &bytes[LIST_LEN_NUM_BYTES..];
 

--- a/object/src/types/list.rs
+++ b/object/src/types/list.rs
@@ -1,4 +1,4 @@
-use crate::{Object, ObjectError};
+use crate::{Object, ObjectError, ObjectKind};
 
 /// The data type used to store the length of List in the payload
 type ListLen = u16;
@@ -7,9 +7,22 @@ const LIST_LEN_NUM_BYTES: usize = std::mem::size_of::<ListLen>();
 
 /// Represents a list in the database
 #[derive(Debug)]
-pub struct List;
+pub struct List(Box<[u8]>);
 
 impl List {
+    /// Get the Len of the list
+    pub fn len(&self) -> ListLen {
+        let mut len = [0; LIST_LEN_NUM_BYTES];
+        len.copy_from_slice(&self.0[..LIST_LEN_NUM_BYTES]);
+
+        ListLen::from_be_bytes(len)
+    }
+
+    /// Create an Int from an Object without verifying if it is valid (this method does not check the object_kind field)
+    pub unsafe fn from_object_unchecked(object: Object) -> Self {
+        Self(object.data)
+    }
+
     /// Validate list data and extract the consumed portion
     /// List format: | 2 bytes count | serialized objects... |
     pub fn validate_and_extract(bytes: &[u8]) -> Result<(&[u8], &[u8]), ObjectError> {
@@ -34,5 +47,26 @@ impl List {
         let consumed_len = bytes.len() - remaining_bytes.len();
         let (consumed, remaining) = bytes.split_at(consumed_len);
         Ok((consumed, remaining))
+    }
+}
+
+impl From<List> for Object {
+    fn from(value: List) -> Self {
+        Self {
+            kind: ObjectKind::List,
+            data: value.0,
+        }
+    }
+}
+
+impl TryFrom<Object> for List {
+    type Error = ObjectError;
+
+    fn try_from(value: Object) -> Result<Self, Self::Error> {
+        if value.kind() == ObjectKind::List {
+            Ok(unsafe { Self::from_object_unchecked(value) })
+        } else {
+            Err(ObjectError)
+        }
     }
 }

--- a/object/src/types/list.rs
+++ b/object/src/types/list.rs
@@ -6,7 +6,7 @@ type ListLen = u16;
 const LIST_LEN_NUM_BYTES: usize = std::mem::size_of::<ListLen>();
 
 /// Represents a list in the database
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct List;
 
 impl List {

--- a/object/src/types/list.rs
+++ b/object/src/types/list.rs
@@ -70,3 +70,62 @@ impl TryFrom<Object> for List {
         }
     }
 }
+
+pub struct ListIterator {
+    bytes_consumed: usize,
+    data: Box<[u8]>,
+}
+
+impl ListIterator {
+    /// Create a new ListIterator
+    fn new(list: List) -> Self {
+        Self {
+            bytes_consumed: LIST_LEN_NUM_BYTES,
+            data: list.0,
+        }
+    }
+}
+
+impl Iterator for ListIterator {
+    type Item = Object;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.bytes_consumed == self.data.len() {
+            None
+        } else {
+            let data = &self.data[self.bytes_consumed..];
+
+            // This data should be in an existing list so it has to be valid
+            // TODO: This calls the normal deserialize method but a deserialize_unchecked may yield benefits
+            let (object, remaining) = unsafe { Object::deserialize(&self.data).unwrap_unchecked() };
+            self.bytes_consumed = data.len() - remaining.len();
+
+            Some(object)
+        }
+    }
+}
+
+impl IntoIterator for List {
+    type Item = Object;
+
+    type IntoIter = ListIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter::new(self)
+    }
+}
+
+impl From<&[Object]> for List {
+    fn from(value: &[Object]) -> Self {
+        let len = value.len() as ListLen;
+
+        // TODO: Investigate if "with_capacity" is possible here
+        let mut data = Vec::new();
+        data.extend(len.to_be_bytes());
+        for object in value {
+            data.extend(object.data());
+        }
+
+        Self(data.into_boxed_slice())
+    }
+}

--- a/object/src/types/list.rs
+++ b/object/src/types/list.rs
@@ -92,8 +92,8 @@ impl Iterator for ListIterator {
 
             // This data should be in an existing list so it has to be valid
             // TODO: This calls the normal deserialize method but a deserialize_unchecked may yield benefits
-            let (object, remaining) = unsafe { Object::deserialize(&self.data).unwrap_unchecked() };
-            self.bytes_consumed = data.len() - remaining.len();
+            let (object, remaining) = unsafe { Object::deserialize(data).unwrap_unchecked() };
+            self.bytes_consumed = self.data.len() - remaining.len();
 
             Some(object)
         }

--- a/object/src/types/map.rs
+++ b/object/src/types/map.rs
@@ -125,7 +125,7 @@ impl Iterator for MapIterator {
                 slice_to_num!(FieldNameLen, &data[..FIELD_NAME_LEN_NUM_BYTES]) as usize;
             let field_name_end_pos = FIELD_COUNT_NUM_BYTES + field_name_len;
             // field name including the number of bytes
-            let field_name = &data[FIELD_NAME_LEN_NUM_BYTES..field_name_end_pos];
+            let field_name = &data[..field_name_end_pos];
 
             // This data should be in an existing map so it has to be valid
             // TODO: This calls the normal deserialize method but a deserialize_unchecked may yield benefits

--- a/object/src/types/map.rs
+++ b/object/src/types/map.rs
@@ -11,7 +11,7 @@ type FieldCount = u16;
 const FIELD_COUNT_NUM_BYTES: usize = std::mem::size_of::<FieldCount>();
 
 /// Represents a map (mapping of field names to objects) in the database
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Map;
 
 impl Map {
@@ -36,7 +36,7 @@ impl Map {
             if remaining_bytes.len() < FIELD_NAME_LEN_NUM_BYTES {
                 return Err(ObjectError);
             }
-            
+
             let mut buffer = [0; FIELD_NAME_LEN_NUM_BYTES];
             buffer.copy_from_slice(&remaining_bytes[..FIELD_NAME_LEN_NUM_BYTES]);
             let field_name_len = FieldNameLen::from_be_bytes(buffer) as usize;
@@ -46,7 +46,7 @@ impl Map {
             if remaining_bytes.len() < field_name_len {
                 return Err(ObjectError);
             }
-            
+
             let field_name_bytes = &remaining_bytes[..field_name_len];
             if std::str::from_utf8(field_name_bytes).is_err() {
                 return Err(ObjectError);

--- a/object/src/types/map.rs
+++ b/object/src/types/map.rs
@@ -165,6 +165,7 @@ impl MapBuilder {
     }
 
     /// Adds a field to the MapBuilder but does not increment the field_count. It requires the field_name (with the prefixed length) as well as the Object
+    // TODO: Should this method be unsafe since if you don't know what you are doing bad things can happen
     pub fn add_field_no_increment(&mut self, field_name: &[u8], object: Object) {
         self.data.extend(field_name);
         self.data.extend(object.serialize());

--- a/object/src/types/null.rs
+++ b/object/src/types/null.rs
@@ -1,4 +1,4 @@
-use crate::ObjectError;
+use crate::{Object, ObjectError, ObjectKind};
 
 /// This represents a null object in the database
 /// so just no value
@@ -6,10 +6,36 @@ use crate::ObjectError;
 pub struct Null;
 
 impl Null {
+    /// Create an Int from an Object without verifying if it is valid (this method does not check the object_kind field)
+    pub unsafe fn from_object_unchecked(_: Object) -> Self {
+        Self
+    }
+
     /// Validate null data and extract the consumed portion
     /// Null objects have no data, so we consume nothing
     pub fn validate_and_extract(bytes: &[u8]) -> Result<(&[u8], &[u8]), ObjectError> {
         // Null has no data, so we return empty slice and all remaining bytes
         Ok((&[], bytes))
+    }
+}
+
+impl From<Null> for Object {
+    fn from(_: Null) -> Self {
+        Self {
+            kind: crate::ObjectKind::Null,
+            data: Box::new([]),
+        }
+    }
+}
+
+impl TryFrom<Object> for Null {
+    type Error = ObjectError;
+
+    fn try_from(value: Object) -> Result<Self, Self::Error> {
+        if value.kind() == ObjectKind::Null {
+            Ok(unsafe { Self::from_object_unchecked(value) })
+        } else {
+            Err(ObjectError)
+        }
     }
 }

--- a/object/src/types/text.rs
+++ b/object/src/types/text.rs
@@ -6,7 +6,7 @@ type TextLen = u16;
 const TEXT_LEN_NUM_BYTES: usize = std::mem::size_of::<TextLen>();
 
 /// Represents a piece of text in the database
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Text;
 
 impl Text {

--- a/object/src/types/text.rs
+++ b/object/src/types/text.rs
@@ -1,4 +1,4 @@
-use crate::ObjectError;
+use crate::{Object, ObjectError, ObjectKind};
 
 /// The data type used to store the length of Text in the payload
 type TextLen = u16;
@@ -7,9 +7,14 @@ const TEXT_LEN_NUM_BYTES: usize = std::mem::size_of::<TextLen>();
 
 /// Represents a piece of text in the database
 #[derive(Debug)]
-pub struct Text;
+pub struct Text(Box<[u8]>);
 
 impl Text {
+    /// Create an Int from an Object without verifying if it is valid (this method does not check the object_kind field)
+    pub unsafe fn from_object_unchecked(object: Object) -> Self {
+        Self(object.data)
+    }
+
     /// Validate text data and extract the consumed portion
     /// Text format: | 2 bytes length | n bytes UTF-8 data |
     pub fn validate_and_extract(bytes: &[u8]) -> Result<(&[u8], &[u8]), ObjectError> {
@@ -35,5 +40,26 @@ impl Text {
 
         let (consumed, remaining) = bytes.split_at(total_size);
         Ok((consumed, remaining))
+    }
+}
+
+impl From<Text> for Object {
+    fn from(value: Text) -> Self {
+        Self {
+            kind: ObjectKind::Text,
+            data: value.0,
+        }
+    }
+}
+
+impl TryFrom<Object> for Text {
+    type Error = ObjectError;
+
+    fn try_from(value: Object) -> Result<Self, Self::Error> {
+        if value.kind() == ObjectKind::Text {
+            Ok(unsafe { Self::from_object_unchecked(value) })
+        } else {
+            Err(ObjectError)
+        }
     }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -90,11 +90,8 @@ impl From<object::ObjectError> for CommandError {
 /// The parameters to use for link resolution
 /// This param has a 1 byte value
 #[derive(Debug)]
-struct LinkResolution {
+pub struct LinkResolution {
     /// The maximum number of times link resolution may take place before exiting
-    /// 0 resolutions means that there is no maximum number of resolutions and
-    /// resolutions should continue until a cyclic dependency or a crash
-    /// 0 should probably not be used
     max_resolutions: u8,
 }
 
@@ -105,7 +102,7 @@ impl LinkResolution {
     }
 
     /// Return the max number of resolutions
-    fn max_resolutions(&self) -> u8 {
+    pub fn max_resolutions(&self) -> u8 {
         self.max_resolutions
     }
 
@@ -126,7 +123,8 @@ impl LinkResolution {
 #[derive(Debug, Default)]
 pub struct GetParams {
     /// Whether links should get resolved or not
-    link_resolution: Option<LinkResolution>,
+    // TODO: should this be pub?
+    pub link_resolution: Option<LinkResolution>,
 }
 
 impl GetParams {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -110,8 +110,6 @@ impl Command {
     const SET: CommandType = 1;
     /// The value for the Delete Command
     const DELETE: CommandType = 2;
-    /// The value for the UpdatedTime Command
-    const UPDATED_TIME: CommandType = 3;
     /// Value for the Close Command
     const CLOSE: CommandType = 255;
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -93,18 +93,20 @@ impl From<object::ObjectError> for CommandError {
 #[derive(Debug)]
 pub struct LinkResolution {
     /// The maximum number of times link resolution may take place before exiting
-    max_resolutions: u8,
+    max_resolution_depth: u8,
 }
 
 impl LinkResolution {
     /// Create a new LinkResolution from bytes
-    fn new(max_resolutions: u8) -> Self {
-        Self { max_resolutions }
+    fn new(max_resolution_depth: u8) -> Self {
+        Self {
+            max_resolution_depth,
+        }
     }
 
     /// Return the max number of resolutions
-    pub fn max_resolutions(&self) -> u8 {
-        self.max_resolutions
+    pub fn max_resolution_depth(&self) -> u8 {
+        self.max_resolution_depth
     }
 
     /// Extract the number of resolutions from bytes to create a LinkResolution and return the remaining bytes

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,4 +1,4 @@
-use object::{Key, Object, ObjectError};
+use object::{Key, Object};
 use std::{
     fmt,
     io::{self, Read, Write},

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -51,6 +51,7 @@ pub enum CommandError {
     /// The Command requested does not exist
     Invalid(CommandType),
     /// There was an issue with the passed in parameters
+    // TODO: This isn't very explicit, passing in an error message would greatly imporove it
     Param,
 }
 
@@ -174,6 +175,8 @@ pub enum Command {
     /// Structure is as follows:
     /// | 8 bytes payload size | 1 byte command type | key | 1 byte num params (optional) | 1 byte param type if param num present| n bytes param value| more params |
     /// Params are passed in as a bitflag. Param values are evaluated from lowest bit value to the highest
+    // TODO: the number of parameters passed in isn't really required but it does allow for further extensibility later on. At some point I should
+    // decide if its needed
     Get(Key, GetParams),
     /// Create an Object in the DB
     /// Structure is as follows:

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -50,6 +50,8 @@ pub enum CommandError {
     Object(object::ObjectError),
     /// The Command requested does not exist
     Invalid(CommandType),
+    /// There was an issue with the passed in parameters
+    Param,
 }
 
 impl fmt::Display for CommandError {
@@ -64,6 +66,9 @@ impl fmt::Display for CommandError {
                 "the command type sent was invalid, received: {}",
                 command_type
             ),
+            CommandError::Param => {
+                write!(f, "an error occured while evaluating passed in parameters",)
+            }
         }
     }
 }
@@ -82,13 +87,96 @@ impl From<object::ObjectError> for CommandError {
     }
 }
 
+/// The parameters to use for link resolution
+/// This param has a 1 byte value
+#[derive(Debug)]
+struct LinkResolution {
+    /// The maximum number of times link resolution may take place before exiting
+    /// 0 resolutions means that there is no maximum number of resolutions and
+    /// resolutions should continue until a cyclic dependency or a crash
+    /// 0 should probably not be used
+    max_resolutions: u8,
+}
+
+impl LinkResolution {
+    /// Create a new LinkResolution from bytes
+    fn new(max_resolutions: u8) -> Self {
+        Self { max_resolutions }
+    }
+
+    /// Return the max number of resolutions
+    fn max_resolutions(&self) -> u8 {
+        self.max_resolutions
+    }
+
+    /// Extract the number of resolutions from bytes to create a LinkResolution and return the remaining bytes
+    /// Returns an error if there is not enough bytes
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), CommandError> {
+        if bytes.is_empty() {
+            Err(CommandError::Param)
+        } else {
+            // Already verified that it is not empty
+            let max_resolutions = unsafe { bytes.get_unchecked(0) };
+            Ok((Self::new(*max_resolutions), &bytes[1..]))
+        }
+    }
+}
+
+/// Contains the params that can be sent along with the get command
+#[derive(Debug, Default)]
+pub struct GetParams {
+    /// Whether links should get resolved or not
+    link_resolution: Option<LinkResolution>,
+}
+
+impl GetParams {
+    /// The number associated with link resolution parameter
+    const LINK_RESOLUTION_VAL: u8 = 1;
+
+    /// Create new GetParams from bytes
+    /// returns a CommandError::Param if there is an erro parsing
+    fn from_bytes(data: &[u8]) -> Result<Self, CommandError> {
+        let mut params = GetParams::default();
+
+        if data.is_empty() {
+            return Ok(params);
+        }
+
+        // getting num params
+        let num_params = unsafe { *data.get_unchecked(0) }; // we know there is at least 1 element
+
+        let mut data = &data[1..];
+        for _ in 0..num_params {
+            // check if there is enough data to continue
+            if data.is_empty() {
+                return Err(CommandError::Param);
+            }
+
+            // getting the param type
+            let param_type = unsafe { *data.get_unchecked(0) }; // we know there is at least 1 element
+
+            match param_type {
+                Self::LINK_RESOLUTION_VAL => {
+                    let (link_resolution, rest) = LinkResolution::from_bytes(&data[1..])?;
+                    params.link_resolution = Some(link_resolution);
+                    data = rest;
+                }
+                _ => return Err(CommandError::Param),
+            }
+        }
+
+        Ok(params)
+    }
+}
+
 /// The kind of commands a client can send
 #[derive(Debug)]
 pub enum Command {
     /// Get an Object from its Key
     /// Structure is as follows:
-    /// | 8 bytes payload size | 1 byte command type | key |
-    Get(Key),
+    /// | 8 bytes payload size | 1 byte command type | key | 1 byte num params (optional) | 1 byte param type if param num present| n bytes param value| more params |
+    /// Params are passed in as a bitflag. Param values are evaluated from lowest bit value to the highest
+    Get(Key, GetParams),
     /// Create an Object in the DB
     /// Structure is as follows:
     /// | 8 bytes payload size | 1 byte command type | key | data object |
@@ -120,20 +208,20 @@ impl Command {
             Self::SET => Self::new_set(data),
             Self::DELETE => Self::new_delete(data),
             Self::CLOSE => Ok(Self::Close),
-            _ => return Err(CommandError::Invalid(command_type)),
+            _ => Err(CommandError::Invalid(command_type)),
         }
-        .map_err(|err| CommandError::Object(err))
     }
 
     /// Creates a new Get command
-    fn new_get(data: Vec<u8>) -> Result<Self, ObjectError> {
+    fn new_get(data: Vec<u8>) -> Result<Self, CommandError> {
         // extract key
-        let (key, _) = Key::new(data.as_slice())?;
-        Ok(Self::Get(key))
+        let (key, rest) = Key::new(data.as_slice())?;
+        let params = GetParams::from_bytes(rest)?;
+        Ok(Self::Get(key, params))
     }
 
     /// Creates a new Set command
-    fn new_set(data: Vec<u8>) -> Result<Self, ObjectError> {
+    fn new_set(data: Vec<u8>) -> Result<Self, CommandError> {
         // first extract Key
         let (key, data) = Key::new(data.as_slice())?;
         Ok(Self::Set(
@@ -143,7 +231,7 @@ impl Command {
     }
 
     /// Creates a new Delete command
-    fn new_delete(data: Vec<u8>) -> Result<Self, ObjectError> {
+    fn new_delete(data: Vec<u8>) -> Result<Self, CommandError> {
         // extract key
         let (key, _) = Key::new(data.as_slice())?;
         Ok(Self::Delete(key))

--- a/storage/src/append_only_log.rs
+++ b/storage/src/append_only_log.rs
@@ -272,7 +272,7 @@ impl<S: Store> AppendOnlyLogStore<S> {
             // Apply the operation to the backing store
             if let Err(e) = match log_entry {
                 Log::Set(key, object) => self.backing_store.store(key, object),
-                Log::Del(key) => self.backing_store.remove(key),
+                Log::Del(key) => self.backing_store.remove(&key),
             } {
                 return Err(AolError::BackingStore(e));
             }
@@ -320,7 +320,7 @@ impl<S: Store> Store for AppendOnlyLogStore<S> {
         self.backing_store.retrieve(key)
     }
 
-    fn remove(&self, key: object::Key) -> StoreResult {
+    fn remove(&self, key: &object::Key) -> StoreResult {
         // create log to delete
         // TODO: get rid of this clone
         let log = Log::Del(key.clone());

--- a/storage/src/append_only_log.rs
+++ b/storage/src/append_only_log.rs
@@ -316,7 +316,7 @@ impl<S: Store> Store for AppendOnlyLogStore<S> {
         }
     }
 
-    fn retrieve(&self, key: object::Key) -> StoreResult {
+    fn retrieve(&self, key: &object::Key) -> StoreResult {
         self.backing_store.retrieve(key)
     }
 

--- a/storage/src/in_memory_store.rs
+++ b/storage/src/in_memory_store.rs
@@ -25,7 +25,7 @@ impl Store for InMemoryStore {
         Ok(self.map.get(key).map(|object| object.clone()).into())
     }
 
-    fn remove(&self, key: object::Key) -> StoreResult {
-        Ok(self.map.remove(&key).into())
+    fn remove(&self, key: &object::Key) -> StoreResult {
+        Ok(self.map.remove(key).into())
     }
 }

--- a/storage/src/in_memory_store.rs
+++ b/storage/src/in_memory_store.rs
@@ -21,8 +21,8 @@ impl Store for InMemoryStore {
         Ok(self.map.insert(key, object).into())
     }
 
-    fn retrieve(&self, key: object::Key) -> StoreResult {
-        Ok(self.map.get(&key).map(|object| object.clone()).into())
+    fn retrieve(&self, key: &object::Key) -> StoreResult {
+        Ok(self.map.get(key).map(|object| object.clone()).into())
     }
 
     fn remove(&self, key: object::Key) -> StoreResult {

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -31,5 +31,5 @@ pub trait Store {
     fn retrieve(&self, key: &Key) -> StoreResult;
 
     /// Delete an Object from from its Key and return the deleted Object
-    fn remove(&self, key: Key) -> StoreResult;
+    fn remove(&self, key: &Key) -> StoreResult;
 }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -28,7 +28,7 @@ pub trait Store {
     fn store(&self, key: Key, object: Object) -> StoreResult;
 
     /// Retrieve an Object from its Key if it exists otherwise return the Null Object
-    fn retrieve(&self, key: Key) -> StoreResult;
+    fn retrieve(&self, key: &Key) -> StoreResult;
 
     /// Delete an Object from from its Key and return the deleted Object
     fn remove(&self, key: Key) -> StoreResult;


### PR DESCRIPTION
This PR introduces a number of things:

1. The Link data type allowing objects to be linked to one another with optional link resolution when the data is queried. Link resolution checks for cycles as well as allows the user to specify the maximum depth of link resolution up until 256 times.
2. Major changes to the Object crate allowing an Object to be converted into its concrete types and vice versa.
3. A complete rewrite of the python client (this was again done by AI).
4. The Get command now has functionality for optional parameters and serves as a framework to include this to other types if needed